### PR TITLE
Ipywidgets5 compat

### DIFF
--- a/examples/Examples.ipynb
+++ b/examples/Examples.ipynb
@@ -37,7 +37,7 @@
    "outputs": [],
    "source": [
     "ball = Mesh(geometry=SphereGeometry(radius=1), material=LambertMaterial(color='red'), position=[2,1,0])\n",
-    "scene = Scene(children=[ball, AmbientLight(color=0x777777), make_text('Hello World!', height=.6)])\n",
+    "scene = Scene(children=[ball, AmbientLight(color='#777777'), make_text('Hello World!', height=.6)])\n",
     "c = PerspectiveCamera(position=[0,5,5], up=[0,0,1], children=[DirectionalLight(color='white', \n",
     "                                                                             position=[3,5,1], \n",
     "                                                                             intensity=0.5)])\n",
@@ -53,23 +53,22 @@
    },
    "outputs": [],
    "source": [
-    "ball.geometry.radius=0.5"
+    "ball.geometry.radius = 0.5"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "import time, math\n",
-    "ball.material.color = 0x4400dd\n",
-    "for i in range(1,150,2):\n",
-    "    ball.geometry.radius=i/100.\n",
-    "    ball.material.color +=0x000300\n",
-    "    ball.position = [math.cos(i/10.), math.sin(i/50.), i/100.]\n",
+    "ball.material.color = '#4400dd'\n",
+    "for i in range(1, 150, 2):\n",
+    "    ball.geometry.radius = i / 100.\n",
+    "    ball.position = [math.cos(i / 10.), math.sin(i / 50.), i / 100.]\n",
     "    time.sleep(.05)"
    ]
   },
@@ -99,12 +98,12 @@
    },
    "outputs": [],
    "source": [
-    "nx,ny=(20,20)\n",
+    "nx, ny = (20, 20)\n",
     "xmax=1\n",
-    "x = np.linspace(-xmax,xmax,nx)\n",
-    "y = np.linspace(-xmax,xmax,ny)\n",
+    "x = np.linspace(-xmax, xmax, nx)\n",
+    "y = np.linspace(-xmax, xmax, ny)\n",
     "xx, yy = np.meshgrid(x,y)\n",
-    "z = xx**2-yy**2\n",
+    "z = xx**2 - yy**2\n",
     "#z[6,1] = float('nan')\n",
     "surf_g = SurfaceGeometry(z=list(z[::-1].flat), \n",
     "                          width=2*xmax,\n",
@@ -115,7 +114,7 @@
     "surf = Mesh(geometry=surf_g, material=LambertMaterial(map=height_texture(z[::-1], 'YlGnBu_r')))\n",
     "surfgrid = SurfaceGrid(geometry=surf_g, material=LineBasicMaterial(color='black'))\n",
     "hover_point = Mesh(geometry=SphereGeometry(radius=0.05), material=LambertMaterial(color='hotpink'))\n",
-    "scene = Scene(children=[surf, surfgrid, hover_point, AmbientLight(color=0x777777)])\n",
+    "scene = Scene(children=[surf, surfgrid, hover_point, AmbientLight(color='#777777')])\n",
     "c = PerspectiveCamera(position=[0,3,3], up=[0,0,1], \n",
     "                      children=[DirectionalLight(color='white', position=[3,5,1], intensity=0.6)])\n",
     "click_picker = Picker(root=surf, event='dblclick')\n",
@@ -194,8 +193,8 @@
     "material = LambertMaterial(map=t)\n",
     "\n",
     "myobject = Mesh(geometry=geometry, material=material)\n",
-    "c = PerspectiveCamera(position=[0,3,3], fov=40, children=[DirectionalLight(color=0xffffff, position=[3,5,1], intensity=0.5)])\n",
-    "scene = Scene(children=[myobject, AmbientLight(color=0x777777)])\n",
+    "c = PerspectiveCamera(position=[0,3,3], fov=40, children=[DirectionalLight(color='#ffffff', position=[3,5,1], intensity=0.5)])\n",
+    "scene = Scene(children=[myobject, AmbientLight(color='#777777')])\n",
     "\n",
     "renderer = Renderer(camera=c, scene = scene, controls=[OrbitControls(controlling=c)])\n",
     "display(renderer)"
@@ -223,7 +222,7 @@
     "lines = Line(geometry=linesgeom, \n",
     "             material=LineBasicMaterial( linewidth=5, vertexColors='VertexColors'), \n",
     "             type='LinePieces')\n",
-    "scene = Scene(children=[lines, DirectionalLight(color=0xccaabb, position=[0,10,0]),AmbientLight(color=0xcccccc)])\n",
+    "scene = Scene(children=[lines, DirectionalLight(color='#ccaabb', position=[0,10,0]),AmbientLight(color='#cccccc')])\n",
     "c = PerspectiveCamera(position=[0,10,10])\n",
     "renderer = Renderer(camera=c, scene = scene, controls=[OrbitControls(controlling=c)])\n",
     "display(renderer)"
@@ -258,7 +257,7 @@
     "                                                                             position=[3,5,1], \n",
     "                                                                             intensity=0.5)])\n",
     "\n",
-    "scene = Scene(children=[sphere, point, AmbientLight(color=0x777777)])\n",
+    "scene = Scene(children=[sphere, point, AmbientLight(color='#777777')])\n",
     "p=Picker(event='mousemove', root=sphere)\n",
     "renderer = Renderer(camera=c, scene = scene, controls=[OrbitControls(controlling=c), p])\n",
     "coords = Text()\n",
@@ -288,7 +287,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -309,7 +308,7 @@
     "\n",
     "surf = Mesh(geometry=surf_g,material=LambertMaterial(color='green', side ='FrontSide'))\n",
     "surf2 = Mesh(geometry=surf_g,material=LambertMaterial(color='yellow', side ='BackSide'))\n",
-    "scene = Scene(children=[surf, surf2, AmbientLight(color=0x777777)])\n",
+    "scene = Scene(children=[surf, surf2, AmbientLight(color='#777777')])\n",
     "c = PerspectiveCamera(position=[5,5,3], up=[0,0,1],children=[DirectionalLight(color='white', position=[3,5,1], intensity=0.6)])\n",
     "renderer = Renderer(camera=c,scene = scene,controls=[OrbitControls(controlling=c)])\n",
     "display(renderer)"
@@ -368,23 +367,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.0"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/Examples.ipynb
+++ b/examples/Examples.ipynb
@@ -11,12 +11,8 @@
     "from pythreejs import *\n",
     "import numpy as np\n",
     "from IPython.display import display\n",
-    "try:\n",
-    "    from ipywidgets import HTML, Text\n",
-    "    from traitlets import link, dlink\n",
-    "except ImportError:\n",
-    "    from IPython.html.widgets import HTML, Text\n",
-    "    from IPython.utils.traitlets import link, dlink"
+    "from ipywidgets import HTML, Text\n",
+    "from traitlets import link, dlink"
    ]
   },
   {
@@ -38,10 +34,10 @@
    "source": [
     "ball = Mesh(geometry=SphereGeometry(radius=1), material=LambertMaterial(color='red'), position=[2,1,0])\n",
     "scene = Scene(children=[ball, AmbientLight(color='#777777'), make_text('Hello World!', height=.6)])\n",
-    "c = PerspectiveCamera(position=[0,5,5], up=[0,0,1], children=[DirectionalLight(color='white', \n",
-    "                                                                             position=[3,5,1], \n",
-    "                                                                             intensity=0.5)])\n",
-    "renderer = Renderer(camera=c, scene = scene, controls=[OrbitControls(controlling=c)])\n",
+    "c = PerspectiveCamera(position=[0, 5, 5],\n",
+    "                      up=[0, 0, 1],\n",
+    "                      children=[DirectionalLight(color='white', position=[3, 5, 1], intensity=0.5)])\n",
+    "renderer = Renderer(camera=c, scene=scene, controls=[OrbitControls(controlling=c)])\n",
     "display(renderer)"
    ]
   },
@@ -73,15 +69,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -102,40 +89,42 @@
     "xmax=1\n",
     "x = np.linspace(-xmax, xmax, nx)\n",
     "y = np.linspace(-xmax, xmax, ny)\n",
-    "xx, yy = np.meshgrid(x,y)\n",
-    "z = xx**2 - yy**2\n",
+    "xx, yy = np.meshgrid(x, y)\n",
+    "z = xx ** 2 - yy ** 2\n",
     "#z[6,1] = float('nan')\n",
     "surf_g = SurfaceGeometry(z=list(z[::-1].flat), \n",
-    "                          width=2*xmax,\n",
-    "                          height=2*xmax,\n",
-    "                          width_segments=nx-1,\n",
-    "                          height_segments=ny-1)\n",
+    "                         width=2 * xmax,\n",
+    "                         height=2 * xmax,\n",
+    "                         width_segments=nx - 1,\n",
+    "                         height_segments=ny - 1)\n",
     "\n",
     "surf = Mesh(geometry=surf_g, material=LambertMaterial(map=height_texture(z[::-1], 'YlGnBu_r')))\n",
     "surfgrid = SurfaceGrid(geometry=surf_g, material=LineBasicMaterial(color='black'))\n",
     "hover_point = Mesh(geometry=SphereGeometry(radius=0.05), material=LambertMaterial(color='hotpink'))\n",
     "scene = Scene(children=[surf, surfgrid, hover_point, AmbientLight(color='#777777')])\n",
-    "c = PerspectiveCamera(position=[0,3,3], up=[0,0,1], \n",
-    "                      children=[DirectionalLight(color='white', position=[3,5,1], intensity=0.6)])\n",
+    "c = PerspectiveCamera(position=[0, 3, 3], up=[0, 0, 1], \n",
+    "                      children=[DirectionalLight(color='white', position=[3, 5, 1], intensity=0.6)])\n",
     "click_picker = Picker(root=surf, event='dblclick')\n",
     "hover_picker = Picker(root=surf, event='mousemove')\n",
     "renderer = Renderer(camera=c, scene = scene, controls=[OrbitControls(controlling=c), click_picker, hover_picker])\n",
     "\n",
-    "def f(name, value):\n",
-    "    print(\"Clicked on %s\"%value)\n",
+    "def f(change):\n",
+    "    value = change['new']\n",
+    "    print('Clicked on %s' % value)\n",
     "    point = Mesh(geometry=SphereGeometry(radius=0.05), \n",
-    "                              material=LambertMaterial(color='red'),\n",
-    "                             position=value)\n",
-    "    scene.children = list(scene.children)+[point]\n",
-    "click_picker.on_trait_change(f, 'point')\n",
+    "                 material=LambertMaterial(color='red'),\n",
+    "                 position=value)\n",
+    "    scene.children = list(scene.children) + [point]\n",
+    "\n",
+    "click_picker.observe(f, names=['point'])\n",
     "\n",
     "link((hover_point, 'position'), (hover_picker, 'point'))\n",
     "\n",
     "h = HTML()\n",
-    "def g(name, value):\n",
-    "    h.value=\"Green point at (%.3f, %.3f, %.3f)\"%tuple(value)\n",
-    "g(None, hover_point.position)\n",
-    "hover_picker.on_trait_change(g, 'point')\n",
+    "def g(change):\n",
+    "    h.value = 'Green point at (%.3f, %.3f, %.3f)' % tuple(change['new'])\n",
+    "g({'new': hover_point.position})\n",
+    "hover_picker.observe(g, names=['point'])\n",
     "display(h)\n",
     "display(renderer)"
    ]
@@ -193,7 +182,8 @@
     "material = LambertMaterial(map=t)\n",
     "\n",
     "myobject = Mesh(geometry=geometry, material=material)\n",
-    "c = PerspectiveCamera(position=[0,3,3], fov=40, children=[DirectionalLight(color='#ffffff', position=[3,5,1], intensity=0.5)])\n",
+    "c = PerspectiveCamera(position=[0, 3, 3], fov=40,\n",
+    "                      children=[DirectionalLight(color='#ffffff', position=[3, 5, 1], intensity=0.5)])\n",
     "scene = Scene(children=[myobject, AmbientLight(color='#777777')])\n",
     "\n",
     "renderer = Renderer(camera=c, scene = scene, controls=[OrbitControls(controlling=c)])\n",
@@ -217,13 +207,18 @@
    "source": [
     "# On windows, linewidth of the material has no effect\n",
     "size = 4\n",
-    "linesgeom = PlainGeometry(vertices=[[0,0,0],[size,0,0],[0,0,0],[0,size,0],[0,0,0],[0,0,size]],\n",
+    "linesgeom = PlainGeometry(vertices=[[0, 0, 0],\n",
+    "                                    [size, 0, 0],\n",
+    "                                    [0, 0, 0],\n",
+    "                                    [0, size, 0],\n",
+    "                                    [0, 0, 0],\n",
+    "                                    [0, 0, size]],\n",
     "                          colors = ['red', 'red', 'green', 'green', 'white', 'orange'])\n",
     "lines = Line(geometry=linesgeom, \n",
-    "             material=LineBasicMaterial( linewidth=5, vertexColors='VertexColors'), \n",
+    "             material=LineBasicMaterial(linewidth=5, vertexColors='VertexColors'), \n",
     "             type='LinePieces')\n",
     "scene = Scene(children=[lines, DirectionalLight(color='#ccaabb', position=[0,10,0]),AmbientLight(color='#cccccc')])\n",
-    "c = PerspectiveCamera(position=[0,10,10])\n",
+    "c = PerspectiveCamera(position=[0, 10, 10])\n",
     "renderer = Renderer(camera=c, scene = scene, controls=[OrbitControls(controlling=c)])\n",
     "display(renderer)"
    ]
@@ -244,22 +239,23 @@
    "outputs": [],
    "source": [
     "geometry = SphereGeometry(radius=4)\n",
-    "t = ImageTexture(imageuri=\"\")\n",
+    "t = ImageTexture(imageuri='')\n",
     "material = LambertMaterial(color='white', map=t)\n",
     "\n",
     "sphere = Mesh(geometry=geometry, material=material)\n",
     "\n",
     "point = Mesh(geometry=SphereGeometry(radius=.1), \n",
-    "                material=LambertMaterial(color='red'))\n",
+    "             material=LambertMaterial(color='red'))\n",
     "\n",
     "\n",
-    "c = PerspectiveCamera(position=[0,10,10], fov=40, children=[DirectionalLight(color='white', \n",
-    "                                                                             position=[3,5,1], \n",
-    "                                                                             intensity=0.5)])\n",
+    "c = PerspectiveCamera(position=[0, 10, 10], fov=40,\n",
+    "                      children=[DirectionalLight(color='white', \n",
+    "                                                 position=[3,5,1], \n",
+    "                                                 intensity=0.5)])\n",
     "\n",
     "scene = Scene(children=[sphere, point, AmbientLight(color='#777777')])\n",
     "p=Picker(event='mousemove', root=sphere)\n",
-    "renderer = Renderer(camera=c, scene = scene, controls=[OrbitControls(controlling=c), p])\n",
+    "renderer = Renderer(camera=c, scene=scene, controls=[OrbitControls(controlling=c), p])\n",
     "coords = Text()\n",
     "display(coords)\n",
     "display(renderer)\n",
@@ -268,7 +264,7 @@
     "#\n",
     "#camera=WebCamera()\n",
     "#display(camera)\n",
-    "#display(Link(widgets=[[camera, 'imageurl'], [t, 'imageuri']]))\n"
+    "#display(Link(widgets=[[camera, 'imageurl'], [t, 'imageuri']]))"
    ]
   },
   {
@@ -306,40 +302,16 @@
     "\"\"\"\n",
     "surf_g = ParametricGeometry(func=f);\n",
     "\n",
-    "surf = Mesh(geometry=surf_g,material=LambertMaterial(color='green', side ='FrontSide'))\n",
-    "surf2 = Mesh(geometry=surf_g,material=LambertMaterial(color='yellow', side ='BackSide'))\n",
+    "surf = Mesh(geometry=surf_g, material=LambertMaterial(color='green', side='FrontSide'))\n",
+    "surf2 = Mesh(geometry=surf_g, material=LambertMaterial(color='yellow', side='BackSide'))\n",
     "scene = Scene(children=[surf, surf2, AmbientLight(color='#777777')])\n",
-    "c = PerspectiveCamera(position=[5,5,3], up=[0,0,1],children=[DirectionalLight(color='white', position=[3,5,1], intensity=0.6)])\n",
-    "renderer = Renderer(camera=c,scene = scene,controls=[OrbitControls(controlling=c)])\n",
+    "c = PerspectiveCamera(position=[5, 5, 3], up=[0, 0, 1],\n",
+    "                      children=[DirectionalLight(color='white',\n",
+    "                                                 position=[3, 5, 1],\n",
+    "                                                 intensity=0.6)])\n",
+    "renderer = Renderer(camera=c, scene=scene, controls=[OrbitControls(controlling=c)])\n",
     "display(renderer)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -354,15 +326,6 @@
     "- parametric geometry\n",
     "- switch between phong, lambert, depth, and wireframe materials, normalmaterial\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/pythreejs/nbextension/pythreejs.js
+++ b/pythreejs/nbextension/pythreejs.js
@@ -1853,7 +1853,7 @@ define(["jupyter-js-widgets", "underscore",
 
     var ParametricGeometryModel = GeometryModel.extend({
         defaults: _.extend({}, GeometryModel.prototype.defaults, {
-            _view_name: 'PrametricGeometryView',
+            _view_name: 'ParametricGeometryView',
             _model_name: 'ParametricGeometryModel',
 
            func: '',

--- a/pythreejs/pythreejs.py
+++ b/pythreejs/pythreejs.py
@@ -6,7 +6,7 @@ In this wrapping of three.js, we try to stay close to the three.js API.  Often, 
 Another resource to understanding three.js decisions is the Udacity course on 3d graphics using three.js: https://www.udacity.com/course/cs291
 """
 
-from ipywidgets import Widget, DOMWidget, widget_serialization
+from ipywidgets import Widget, DOMWidget, widget_serialization, Color
 from traitlets import (Unicode, Int, Instance, Enum, List, Dict, Float,
                        Any, CFloat, Bool, This, CInt, TraitType)
 from math import pi, sqrt
@@ -20,44 +20,6 @@ def vector2(trait_type=CFloat, default=None, **kwargs):
     if default is None:
         default=[0, 0]
     return List(trait_type, default_value=default, minlen=2, maxlen=2, **kwargs)
-
-
-# python 3 compatibility stuff
-# http://www.voidspace.org.uk/python/articles/porting-mock-to-python-3.shtml
-try:
-    unicode
-except NameError:
-    # Python 3
-    basestring = unicode = str
-
-
-class Color(TraitType):
-    """A color trait.
-
-    This takes a color represented as:
-
-    * a string of the form ``'rgb(255, 0, 0)'``, ``'rgb(100%, 0%, 0%)'``, ``'#ff0000'``, ``'#f00'``, or a color name (see the THREE.ColorKeywords listing at https://github.com/mrdoob/three.js/blob/master/src/math/Color.js)
-    * an rgb tuple/list of numbers, each between 0 and 1
-    * an integer (or hex value)
-    """
-    default_value = 'black'
-    info_text = 'a color as an rgb tuple, an integer, or a string'
-
-    def validate(self, obj, value):
-        if isinstance(value, (tuple, list)) and len(value)==3:
-            return 'rgb(%d,%d,%d)'%(int(value[0]), int(value[1]), int(value[2]))
-        elif isinstance(value, basestring):
-            # from https://github.com/mrdoob/three.js/blob/master/src/math/Color.js
-            # there are lots of color names, as well as things like
-            # rgb(?,?,?), rgb(?%,?%,?%), #XXXXXX, #XXX
-            # TODO: validate one of those patterns, or just pass the buck to three.js
-            return value
-        else:
-            try:
-                return int(value)
-            except:
-                pass
-        self.error(obj, value)
 
 
 class Texture(Widget):
@@ -133,8 +95,8 @@ class Object3d(Widget):
         y = m[4:7]
         z = m[8:11]
         self.scale = [self.vector_length(x),
-                        self.vector_length(y),
-                        self.vector_length(z)]
+                      self.vector_length(y),
+                      self.vector_length(z)]
         m=[]
         m.extend(x)
         m.extend(y)
@@ -153,7 +115,7 @@ class Object3d(Widget):
         x = m[0:3]
         y = m[3:6]
         z = m[6:9]
-        trace = x[0]+y[1]+z[2]
+        trace = x[0] + y[1] + z[2]
         if (trace>0):
             s = 0.5/sqrt(trace+1)
             self.quaternion = [(y[2]-z[1])*s, (z[0]-x[2])*s, (x[1]-y[0])*s, 0.25/s]
@@ -188,7 +150,9 @@ class Object3d(Widget):
         return [x[1]*y[2]-x[2]*y[1], x[2]*y[0]-x[0]*y[2], x[0]*y[1]-x[1]*y[0]]
 
     def look_at(self, eye, target):
-        z = self.normalize([eye[0]-target[0], eye[1]-target[1], eye[2]-target[2]]) # eye - target
+        z = self.normalize([eye[0] - target[0],
+                            eye[1] - target[1],
+                            eye[2] - target[2]])  # eye - target
 
         if (self.vector_length(z)==0):
             z[2]=1
@@ -688,7 +652,7 @@ class AnaglyphEffect(Effect):
     _view_name = Unicode('AnaglyphEffectView').tag(sync=True)
 
 
-class Renderer(Widget):
+class Renderer(DOMWidget):
     _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
     _view_name = Unicode('RendererView').tag(sync=True)
     _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)

--- a/pythreejs/pythreejs.py
+++ b/pythreejs/pythreejs.py
@@ -540,6 +540,7 @@ class DepthMaterial(Material):
 
 class _LineMaterial(Material):
     """Abstract base class for line materials"""
+    pass
 
 
 class LineBasicMaterial(_LineMaterial):

--- a/pythreejs/pythreejs.py
+++ b/pythreejs/pythreejs.py
@@ -759,8 +759,8 @@ class Renderer(DOMWidget):
     _view_name = Unicode('RendererView').tag(sync=True)
     _model_name = Unicode('RendererModel').tag(sync=True)
 
-    width = CInt(600).tag(sync=True)
-    height = CInt(400).tag(sync=True)
+    width = Unicode('600').tag(sync=True)  # TODO: stop relying on deprecated DOMWidget attribute
+    height = Unicode('400').tag(sync=True) 
     renderer_type = Enum(['webgl', 'canvas', 'auto'], 'auto').tag(sync=True)
     scene = Instance(Scene).tag(sync=True, **widget_serialization)
     camera = Instance(Camera).tag(sync=True, **widget_serialization)

--- a/pythreejs/pythreejs.py
+++ b/pythreejs/pythreejs.py
@@ -6,31 +6,20 @@ In this wrapping of three.js, we try to stay close to the three.js API.  Often, 
 Another resource to understanding three.js decisions is the Udacity course on 3d graphics using three.js: https://www.udacity.com/course/cs291
 """
 
-
-# Import the base Widget class and the traitlets Unicode class.
-try:
-    from ipywidgets import Widget, DOMWidget, widget_serialization
-    from traitlets import (Unicode, Int, Instance, Enum, List, Dict, Float,
-                           Any, CFloat, Bool, This, CInt, TraitType)
-except ImportError:  # IPython 3.x
-    from IPython.html.widgets.widget import Widget, DOMWidget
-    from IPython.utils.traitlets import (Unicode, Int, Instance, Enum, List, Dict, Float,
-                                         Any, CFloat, Bool, This, CInt, TraitType)
-    widget_serialization = {}
+from ipywidgets import Widget, DOMWidget, widget_serialization
+from traitlets import (Unicode, Int, Instance, Enum, List, Dict, Float,
+                       Any, CFloat, Bool, This, CInt, TraitType)
 from math import pi, sqrt
 
 def vector3(trait_type=CFloat, default=None, **kwargs):
-    if default is None: 
-        default=[0,0,0]
-    return List(trait_type, default_value=default, 
-                minlen=3, maxlen=3, allow_none=False, **kwargs)
+    if default is None:
+        default=[0, 0, 0]
+    return List(trait_type, default_value=default, minlen=3, maxlen=3, **kwargs)
 
 def vector2(trait_type=CFloat, default=None, **kwargs):
-    if default is None: 
-        default=[0,0]
-    return List(trait_type, default_value=default, 
-                minlen=2, maxlen=2, allow_none=False, **kwargs)
-
+    if default is None:
+        default=[0, 0]
+    return List(trait_type, default_value=default, minlen=2, maxlen=2, **kwargs)
 
 
 # python 3 compatibility stuff
@@ -40,6 +29,7 @@ try:
 except NameError:
     # Python 3
     basestring = unicode = str
+
 
 class Color(TraitType):
     """A color trait.
@@ -69,70 +59,73 @@ class Color(TraitType):
                 pass
         self.error(obj, value)
 
+
 class Texture(Widget):
-    _view_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
-    _view_name = Unicode('TextureView', sync=True)
+    _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _view_name = Unicode('TextureView').tag(sync=True)
+
 
 class ImageTexture(Texture):
     """An image texture.
 
     The imageuri can be a data url or a web url.
     """
-    _view_name = Unicode('ImageTextureView', sync=True)
-    imageuri = Unicode('',sync=True)
+    _view_name = Unicode('ImageTextureView').tag(sync=True)
+    imageuri = Unicode().tag(sync=True)
+
 
 class DataTexture(Texture):
     """A data-based texture.
 
-    See http://threejs.org/docs/#Reference/Textures/DataTexture.  
+    See http://threejs.org/docs/#Reference/Textures/DataTexture.
     """
-    _view_name = Unicode('DataTextureView', sync=True)
-    data = List(CInt, sync=True)
+    _view_name = Unicode('DataTextureView').tag(sync=True)
+    data = List(CInt).tag(sync=True)
     format = Enum(['RGBAFormat', 'AlphaFormat', 'RGBFormat', 'LuminanceFormat', 'LuminanceAlphaFormat'],
-                'RGBAFormat', sync=True)
-    width = CInt(256, sync=True)
-    height = CInt(256, sync=True)
+            'RGBAFormat').tag(sync=True)
+    width = CInt(256).tag(sync=True)
+    height = CInt(256).tag(sync=True)
     type = Enum(['UnsignedByteType', 'ByteType', 'ShortType', 'UnsignedShortType', 'IntType',
-                'UnsignedIntType', 'FloatType', 'UnsignedShort4444Type', 'UnsignedShort5551Type',
-                'UnsignedShort565Type'], 'UnsignedByteType', sync=True)
+                 'UnsignedIntType', 'FloatType', 'UnsignedShort4444Type', 'UnsignedShort5551Type',
+                 'UnsignedShort565Type'], 'UnsignedByteType').tag(sync=True)
     mapping = Enum(['UVMapping', 'CubeReflectionMapping', 'CubeRefractionMapping', 'SphericalReflectionMapping',
-                    'SphericalRefractionMapping'], 'UVMapping', sync=True)
-    wrapS = Enum(['ClampToEdgeWrapping', 'RepeatWrapping', 'MirroredRepeatWrapping'], 'ClampToEdgeWrapping',
-                sync=True)
-    wrapT = Enum(['ClampToEdgeWrapping', 'RepeatWrapping', 'MirroredRepeatWrapping'], 'ClampToEdgeWrapping',
-                sync=True)
-    magFilter = Enum(['LinearFilter', 'NearestFilter'], 'LinearFilter', sync=True)
+                    'SphericalRefractionMapping'], 'UVMapping').tag(sync=True)
+    wrapS = Enum(['ClampToEdgeWrapping', 'RepeatWrapping', 'MirroredRepeatWrapping'], 'ClampToEdgeWrapping').tag(sync=True)
+    wrapT = Enum(['ClampToEdgeWrapping', 'RepeatWrapping', 'MirroredRepeatWrapping'], 'ClampToEdgeWrapping').tag(sync=True)
+    magFilter = Enum(['LinearFilter', 'NearestFilter'], 'LinearFilter').tag(sync=True)
     minFilter = Enum(['NearestFilter', 'NearestMipMapNearestFilter', 'NearestMipMapLinearFilter',
-                        'LinearFilter', 'LinearMipMapNearestFilter'], 'NearestFilter', sync=True)
-    anisotropy = CInt(1, sync=True)
+                      'LinearFilter', 'LinearMipMapNearestFilter'], 'NearestFilter').tag(sync=True)
+    anisotropy = CInt(1).tag(sync=True)
+
 
 class TextTexture(Texture):
-    _view_name = Unicode('TextTextureView', sync=True)
-    fontFace = Unicode('Arial', sync=True)
-    size = CInt(12, sync=True)
-    color = Color('black', sync=True)
-    string = Unicode('', sync=True)
-    squareTexture = Bool(True, sync=True)
+    _view_name = Unicode('TextTextureView').tag(sync=True)
+    fontFace = Unicode('Arial').tag(sync=True)
+    size = CInt(12).tag(sync=True)
+    color = Color('black').tag(sync=True)
+    string = Unicode(sync=True)
+    squareTexture = Bool(True).tag(sync=True)
+
 
 class Object3d(Widget):
     """
     If matrix is not None, it overrides the position, rotation, scale, and up variables.
     """
-    _view_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
-    _view_name = Unicode('Object3dView', sync=True)
-    _model_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
-    _model_name = Unicode('Object3dModel', sync=True)
-    position = vector3(CFloat, sync=True)
-    quaternion = List(CFloat, sync=True) # [x,y,z,w]
-    scale = vector3(CFloat, [1,1,1], sync=True)
-    up = vector3(CFloat, [0,1,0], sync=True)
-    visible = Bool(True, sync=True)
-    castShadow = Bool(False, sync=True)
-    receiveShadow = Bool(False, sync=True)
+    _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _view_name = Unicode('Object3dView').tag(sync=True)
+    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _model_name = Unicode('Object3dModel').tag(sync=True)
+    position = vector3(CFloat).tag(sync=True)
+    quaternion = List(CFloat).tag(sync=True) # [x,y,z,w]
+    scale = vector3(CFloat, [1, 1, 1]).tag(sync=True)
+    up = vector3(CFloat, [0, 1, 0]).tag(sync=True)
+    visible = Bool(True).tag(sync=True)
+    castShadow = Bool(sync=True)
+    receiveShadow = Bool(sync=True)
     # FYI, this matrix has the translation in the 4th row, which is is the
     # transpose of Sage's transformation matrices
     # TODO: figure out how to get a list of instances of Object3d
-    children = List(trait=None, default_value=[], allow_none=False, sync=True, **widget_serialization)
+    children = List().tag(sync=True, **widget_serialization)
 
     def set_matrix(self, m):
         self.position = m[12:15]
@@ -175,14 +168,14 @@ class Object3d(Widget):
             self.quaternion = [(z[0]+x[2])/s, (z[1]+y[2])/s, 0.25*s, (x[1]-y[0])/s]
 
     def vector_length(self, x):
-        return sqrt(x[0]*x[0]+x[1]*x[1]+x[2]*x[2])
+        return sqrt(x[0] * x[0] + x[1] * x[1] + x[2] * x[2])
 
     def vector_divide_scalar(self, scalar, x):
-        if (scalar!=0):
-            x[0] = x[0]/scalar
-            x[1] = x[1]/scalar
-            x[2] = x[2]/scalar
-        else: 
+        if (scalar != 0):
+            x[0] = x[0] / scalar
+            x[1] = x[1] / scalar
+            x[2] = x[2] / scalar
+        else:
             x[0] = 0
             x[1] = 0
             x[2] = 0
@@ -211,7 +204,7 @@ class Object3d(Widget):
         m.extend(y)
         m.extend(z)
         self.quaternion_from_rotation(m)
-        
+
 
 class ScaledObject(Object3d):
     """
@@ -220,345 +213,383 @@ class ScaledObject(Object3d):
 
     The idea is that it is the parent for objects you want to maintain the same scale.
     """
-    _view_name = Unicode('ScaledObjectView', sync=True)
+    _view_name = Unicode('ScaledObjectView').tag(sync=True)
+
 
 class Controls(Widget):
-    _view_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
-    _view_name = Unicode('ControlsView', sync=True)
-    _model_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
-    _model_name = Unicode('ControlsModel', sync=True)
-    controlling = Instance(Object3d, sync=True, allow_none=True, **widget_serialization)
+    _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _view_name = Unicode('ControlsView').tag(sync=True)
+    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _model_name = Unicode('ControlsModel').tag(sync=True)
+    controlling = Instance(Object3d, allow_none=True).tag(sync=True, **widget_serialization)
+
 
 class OrbitControls(Controls):
-    _view_name = Unicode('OrbitControlsView', sync=True)
-    target = vector3(CFloat, sync=True)
+    _view_name = Unicode('OrbitControlsView').tag(sync=True)
+    target = vector3(CFloat).tag(sync=True)
+
 
 class TrackballControls(Controls):
-    _view_name = Unicode('TrackballControlsView', sync=True)
-    target = vector3(CFloat, sync=True)
+    _view_name = Unicode('TrackballControlsView').tag(sync=True)
+    target = vector3(CFloat).tag(sync=True)
+
 
 class FlyControls(Controls):
-    _view_name = Unicode('FlyControlsView', sync=True)
+    _view_name = Unicode('FlyControlsView').tag(sync=True)
 
-    forward_speed = Float(sync=True)
-    lateral_speed = Float(sync=True)
-    upward_speed = Float(sync=True)
-    roll = Float(sync=True)
-    pitch = Float(sync=True)
-    yaw = Float(sync=True)
+    forward_speed = Float().tag(sync=True)
+    lateral_speed = Float().tag(sync=True)
+    upward_speed = Float().tag(sync=True)
+    roll = Float().tag(sync=True)
+    pitch = Float().tag(sync=True)
+    yaw = Float().tag(sync=True)
+
 
 class Picker(Controls):
-    _view_name  = Unicode('PickerView', sync=True)
-    _model_name  = Unicode('PickerModel', sync=True)
-    event = Unicode('click', sync=True)
-    root = Instance(Object3d, sync=True, allow_none=True, **widget_serialization)
-    picked = List(Dict, sync=True)
-    distance = CFloat(sync=True)
-    point = vector3(CFloat, sync=True)
-    object = Instance(Object3d, sync=True, allow_none=True, **widget_serialization)
-    face = vector3(CInt, sync=True)
-    faceNormal = vector3(CFloat, sync=True)
-    faceVertices = List(vector3(), sync=True)
+    _view_name  = Unicode('PickerView').tag(sync=True)
+    _model_name  = Unicode('PickerModel').tag(sync=True)
+    event = Unicode('click').tag(sync=True)
+    root = Instance(Object3d, allow_none=True).tag(sync=True, **widget_serialization)
+    picked = List(Dict).tag(sync=True)
+    distance = CFloat().tag(sync=True)
+    point = vector3(CFloat).tag(sync=True)
+    object = Instance(Object3d, allow_none=True).tag(sync=True, **widget_serialization)
+    face = vector3(CInt).tag(sync=True)
+    faceNormal = vector3(CFloat).tag(sync=True)
+    faceVertices = List(vector3()).tag(sync=True)
     faceIndex = CInt(sync=True)
-    all = Bool(False, sync=True)
-    
+    all = Bool(sync=True)
+
+
 class Geometry(Widget):
-    _view_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)    
-    _view_name = Unicode('GeometryView', sync=True)
+    _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _view_name = Unicode('GeometryView').tag(sync=True)
+
 
 class PlainGeometry(Geometry):
-    _view_name = Unicode('PlainGeometryView', sync=True)
-    vertices = List(vector3(CFloat), sync=True)
-    colors = List(Color, sync=True)
-    faces = List(List(CFloat), sync=True)
-    # todo: faceVertexUvs = List(vector3(vector2(CFloat)), sync=True)
-    
+    _view_name = Unicode('PlainGeometryView').tag(sync=True)
+    vertices = List(vector3(CFloat)).tag(sync=True)
+    colors = List(Color).tag(sync=True)
+    faces = List(List(CFloat)).tag(sync=True)
+    # todo: faceVertexUvs = List(vector3(vector2(CFloat))).tag(sync=True)
+
+
 class SphereGeometry(Geometry):
-    _view_name = Unicode('SphereGeometryView', sync=True)
-    radius = CFloat(1, sync=True)
-    
+    _view_name = Unicode('SphereGeometryView').tag(sync=True)
+    radius = CFloat(1).tag(sync=True)
+
+
 class CylinderGeometry(Geometry):
-    _view_name = Unicode('CylinderGeometryView', sync=True)
-    radiusTop = CFloat(1, sync=True)
-    radiusBottom = CFloat(1, sync=True)
-    height = CFloat(1, sync=True)
-    radiusSegments = CFloat(20, sync=True)
-    heightSegments = CFloat(1, sync=True)
-    openEnded = Bool(False, sync=True)
-    
+    _view_name = Unicode('CylinderGeometryView').tag(sync=True)
+    radiusTop = CFloat(1).tag(sync=True)
+    radiusBottom = CFloat(1).tag(sync=True)
+    height = CFloat(1).tag(sync=True)
+    radiusSegments = CFloat(20).tag(sync=True)
+    heightSegments = CFloat(1).tag(sync=True)
+    openEnded = Bool(sync=True)
+
+
 class BoxGeometry(Geometry):
-    _view_name = Unicode('BoxGeometryView', sync=True)
-    width = CFloat(1, sync=True)
-    height = CFloat(1, sync=True)
-    depth = CFloat(1, sync=True)
-    widthSegments = CFloat(1, sync=True)
-    heightSegments = CFloat(1, sync=True)
-    depthSegments = CFloat(1, sync=True)
-    
+    _view_name = Unicode('BoxGeometryView').tag(sync=True)
+    width = CFloat(1).tag(sync=True)
+    height = CFloat(1).tag(sync=True)
+    depth = CFloat(1).tag(sync=True)
+    widthSegments = CFloat(1).tag(sync=True)
+    heightSegments = CFloat(1).tag(sync=True)
+    depthSegments = CFloat(1).tag(sync=True)
+
+
 class CircleGeometry(Geometry):
-    _view_name = Unicode('CircleGeometryView', sync=True)
-    radius = CFloat(1, sync=True)
-    segments = CFloat(8, sync=True)
-    thetaStart = CFloat(0, sync=True)
-    thetaLength = CFloat(2*pi, sync=True)
-    
+    _view_name = Unicode('CircleGeometryView').tag(sync=True)
+    radius = CFloat(1).tag(sync=True)
+    segments = CFloat(8).tag(sync=True)
+    thetaStart = CFloat(0).tag(sync=True)
+    thetaLength = CFloat(2*pi).tag(sync=True)
+
+
 class LatheGeometry(Geometry):
-    _view_name = Unicode('LatheGeometryView', sync=True)
-    points = List(vector3(), sync=True)
-    segments = CInt(12, sync=True)
-    phiStart = CFloat(0, sync=True)
-    phiLength = CFloat(2*pi, sync=True)
+    _view_name = Unicode('LatheGeometryView').tag(sync=True)
+    points = List(vector3()).tag(sync=True)
+    segments = CInt(12).tag(sync=True)
+    phiStart = CFloat(0).tag(sync=True)
+    phiLength = CFloat(2*pi).tag(sync=True)
+
 
 class TubeGeometry(Geometry):
-    _view_name = Unicode('TubeGeometryView', sync=True)
-    path = List(vector3(), sync=True)
-    segments = CInt(64, sync=True)
-    radius = CFloat(1, sync=True)
-    radialSegments = CFloat(8, sync=True)
-    closed = Bool(False, sync=True)
+    _view_name = Unicode('TubeGeometryView').tag(sync=True)
+    path = List(vector3()).tag(sync=True)
+    segments = CInt(64).tag(sync=True)
+    radius = CFloat(1).tag(sync=True)
+    radialSegments = CFloat(8).tag(sync=True)
+    closed = Bool(sync=True)
+
 
 class IcosahedronGeometry(Geometry):
-    _view_name = Unicode('IcosahedronGeometryView', sync=True)
-    radius = CFloat(1, sync=True)
-    detail = CFloat(0, sync=True)
-    
+    _view_name = Unicode('IcosahedronGeometryView').tag(sync=True)
+    radius = CFloat(1).tag(sync=True)
+    detail = CFloat(0).tag(sync=True)
+
+
 class OctahedronGeometry(Geometry):
-    _view_name = Unicode('OctahedronGeometryView', sync=True)
-    radius = CFloat(1, sync=True)
-    detail = CFloat(0, sync=True)
-    
+    _view_name = Unicode('OctahedronGeometryView').tag(sync=True)
+    radius = CFloat(1).tag(sync=True)
+    detail = CFloat(0).tag(sync=True)
+
+
 class PlaneGeometry(Geometry):
-    _view_name = Unicode('PlaneGeometryView', sync=True)
-    width = CFloat(1, sync=True)
-    height = CFloat(1, sync=True)
-    widthSegments = CFloat(1, sync=True)
-    heightSegments = CFloat(1, sync=True)
-    
+    _view_name = Unicode('PlaneGeometryView').tag(sync=True)
+    width = CFloat(1).tag(sync=True)
+    height = CFloat(1).tag(sync=True)
+    widthSegments = CFloat(1).tag(sync=True)
+    heightSegments = CFloat(1).tag(sync=True)
+
+
 class TetrahedronGeometry(Geometry):
-    _view_name = Unicode('TetrahedronGeometryView', sync=True)
-    radius = CFloat(1, sync=True)
-    detail = CFloat(0, sync=True)
-    
+    _view_name = Unicode('TetrahedronGeometryView').tag(sync=True)
+    radius = CFloat(1).tag(sync=True)
+    detail = CFloat(0).tag(sync=True)
+
+
 class TorusGeometry(Geometry):
-    _view_name = Unicode('TorusGeometryView', sync=True)
-    radius = CFloat(1, sync=True)
-    tube = CFloat(1, sync=True)
-    radialSegments = CFloat(1, sync=True)
-    tubularSegments = CFloat(1, sync=True)
-    arc = CFloat(pi*2, sync=True)
-    
+    _view_name = Unicode('TorusGeometryView').tag(sync=True)
+    radius = CFloat(1).tag(sync=True)
+    tube = CFloat(1).tag(sync=True)
+    radialSegments = CFloat(1).tag(sync=True)
+    tubularSegments = CFloat(1).tag(sync=True)
+    arc = CFloat(pi*2).tag(sync=True)
+
+
 class TorusKnotGeometry(Geometry):
-    _view_name = Unicode('TorusKnotGeometryView', sync=True)
-    radius = CFloat(1, sync=True)
-    tube = CFloat(1, sync=True)
-    radialSegments = CFloat(10, sync=True)
-    tubularSegments = CFloat(10, sync=True)
-    p = CFloat(2, sync=True)
-    q = CFloat(3, sync=True)
-    heightScale = CFloat(1, sync=True)
-    
+    _view_name = Unicode('TorusKnotGeometryView').tag(sync=True)
+    radius = CFloat(1).tag(sync=True)
+    tube = CFloat(1).tag(sync=True)
+    radialSegments = CFloat(10).tag(sync=True)
+    tubularSegments = CFloat(10).tag(sync=True)
+    p = CFloat(2).tag(sync=True)
+    q = CFloat(3).tag(sync=True)
+    heightScale = CFloat(1).tag(sync=True)
+
+
 class PolyhedronGeometry(Geometry):
-    _view_name = Unicode('PolyhedronGeometryView', sync=True)
-    radius = CFloat(1, sync=True)
-    detail = CInt(0, sync=True)
-    vertices = List(List(CFloat), sync=True)
-    faces = List(List(CInt), sync=True)
+    _view_name = Unicode('PolyhedronGeometryView').tag(sync=True)
+    radius = CFloat(1).tag(sync=True)
+    detail = CInt(0).tag(sync=True)
+    vertices = List(List(CFloat)).tag(sync=True)
+    faces = List(List(CInt)).tag(sync=True)
+
 
 class RingGeometry(Geometry):
-    _view_name = Unicode('RingGeometryView', sync=True)
-    innerRadius = CFloat(1.0, sync=True)
-    outerRadius = CFloat(3.0, sync=True)
-    thetaSegments = CInt(8, sync=True)
-    phiSegments = CInt(8, sync=True)
-    thetaStart = CFloat(0, sync=True)
-    thetaLength = CFloat(pi*2, sync=True)
+    _view_name = Unicode('RingGeometryView').tag(sync=True)
+    innerRadius = CFloat(1.0).tag(sync=True)
+    outerRadius = CFloat(3.0).tag(sync=True)
+    thetaSegments = CInt(8).tag(sync=True)
+    phiSegments = CInt(8).tag(sync=True)
+    thetaStart = CFloat(0).tag(sync=True)
+    thetaLength = CFloat(pi*2).tag(sync=True)
+
 
 class SurfaceGeometry(Geometry):
     """
     A regular grid with heights
     """
-    _view_name = Unicode('SurfaceGeometryView', sync=True)
-    z = List(CFloat, [0]*100, sync=True)
-    width = CInt(10, sync=True)
-    height = CInt(10, sync=True)
-    width_segments = CInt(10, sync=True)
-    height_segments = CInt(10, sync=True)
+    _view_name = Unicode('SurfaceGeometryView').tag(sync=True)
+    z = List(CFloat, [0]*100).tag(sync=True)
+    width = CInt(10).tag(sync=True)
+    height = CInt(10).tag(sync=True)
+    width_segments = CInt(10).tag(sync=True)
+    height_segments = CInt(10).tag(sync=True)
+
 
 class FaceGeometry(Geometry):
     """
     List of vertices and faces
     """
-    _view_name = Unicode('FaceGeometryView', sync=True)
-    vertices = List(CFloat, sync=True) # [x0, y0, z0, x1, y1, z1, x2, y2, z2, ...]
-    face3 = List(CInt, sync=True) # [v0,v1,v2, v0,v1,v2, v0,v1,v2, ...]
-    face4 = List(CInt, sync=True) # [v0,v1,v2,v3, v0,v1,v2,v3, v0,v1,v2,v3, ...]
-    facen = List(List(CInt), sync=True) # [[v0,v1,v2,...,vn], [v0,v1,v2,...,vn], [v0,v1,v2,...,vn], ...]
+    _view_name = Unicode('FaceGeometryView').tag(sync=True)
+    vertices = List(CFloat).tag(sync=True)  # [x0, y0, z0, x1, y1, z1, x2, y2, z2, ...]
+    face3 = List(CInt).tag(sync=True)  # [v0,v1,v2, v0,v1,v2, v0,v1,v2, ...]
+    face4 = List(CInt).tag(sync=True)  # [v0,v1,v2,v3, v0,v1,v2,v3, v0,v1,v2,v3, ...]
+    facen = List(List(CInt)).tag(sync=True)  # [[v0,v1,v2,...,vn], [v0,v1,v2,...,vn], [v0,v1,v2,...,vn], ...]
+
 
 class ParametricGeometry(Geometry):
-    _view_name = Unicode('ParametricGeometryView', sync=True)
-    func = Unicode('', sync=True)
-    slices = CInt(105, sync=True)
+    _view_name = Unicode('ParametricGeometryView').tag(sync=True)
+    func = Unicode(sync=True)
+    slices = CInt(105).tag(sync=True)
     stacks = CInt(105,sync=True)
-    
+
+
 class Material(Widget):
-    _view_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
-    _view_name = Unicode('MaterialView', sync=True)
+    _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _view_name = Unicode('MaterialView').tag(sync=True)
     # id = TODO
-    name = Unicode('', sync=True) 
-    side = Enum(['FrontSide', 'BackSide', 'DoubleSide'], 'DoubleSide',  sync=True) 
-    opacity = CFloat(1.0, sync=True)
-    transparent = Bool(False, sync=True)
+    name = Unicode(sync=True)
+    side = Enum(['FrontSide', 'BackSide', 'DoubleSide'], 'DoubleSide').tag(sync=True)
+    opacity = CFloat(1.0).tag(sync=True)
+    transparent = Bool(sync=True)
     blending = Enum(['NoBlending', 'NormalBlending', 'AdditiveBlending', 'SubtractiveBlending', 'MultiplyBlending',
-                    'CustomBlending'], 'NormalBlending', sync=True) 
+                    'CustomBlending'], 'NormalBlending').tag(sync=True)
     blendSrc = Enum(['ZeroFactor', 'OneFactor', 'SrcColorFactor', 'OneMinusSrcColorFactor', 'SrcAlphaFactor',
-                    'OneMinusSrcAlphaFactor', 'DstAlphaFactor', 'OneMinusDstAlphaFactor'], 'SrcAlphaFactor', sync=True) 
-    blendDst = Enum(['DstColorFactor', 'OneMinusDstColorFactor', 'SrcAlphaSaturateFactor'], 'OneMinusDstColorFactor',
-                    sync=True)
-    blendEquation = Enum(['AddEquation', 'SubtractEquation', 'ReverseSubtractEquation'], 'AddEquation', sync=True)
-    depthTest = Bool(True, sync=True) 
-    depthWrite = Bool(True, sync=True) 
-    polygonOffset = Bool(True, sync=True) 
-    polygonOffsetFactor = CFloat(1.0, sync=True) 
-    polygonOffsetUnits = CFloat(1.0, sync=True) 
-    alphaTest = CFloat(1.0, sync=True) 
-    overdraw = CFloat(1.0, sync=True) 
-    visible = Bool(True, sync=True) 
-    needsUpdate = Bool(True, sync=True) 
-    
+                    'OneMinusSrcAlphaFactor', 'DstAlphaFactor', 'OneMinusDstAlphaFactor'], 'SrcAlphaFactor').tag(sync=True)
+    blendDst = Enum(['DstColorFactor', 'OneMinusDstColorFactor', 'SrcAlphaSaturateFactor'], 'OneMinusDstColorFactor').tag(sync=True)
+    blendEquation = Enum(['AddEquation', 'SubtractEquation', 'ReverseSubtractEquation'], 'AddEquation').tag(sync=True)
+    depthTest = Bool(True).tag(sync=True)
+    depthWrite = Bool(True).tag(sync=True)
+    polygonOffset = Bool(True).tag(sync=True)
+    polygonOffsetFactor = CFloat(1.0).tag(sync=True)
+    polygonOffsetUnits = CFloat(1.0).tag(sync=True)
+    alphaTest = CFloat(1.0).tag(sync=True)
+    overdraw = CFloat(1.0).tag(sync=True)
+    visible = Bool(True).tag(sync=True)
+    needsUpdate = Bool(True).tag(sync=True)
+
+
 class BasicMaterial(Material):
-    _view_name = Unicode('BasicMaterialView', sync=True)
-    _model_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
-    _model_name = Unicode('BasicMaterialModel', sync=True)
-    color = Color('white', sync=True)
-    wireframe = Bool(False, sync=True)
-    wireframeLinewidth = CFloat(1.0, sync=True)
-    wireframeLinecap = Unicode('round', sync=True)
-    wireframeLinejoin = Unicode('round', sync=True)
-    shading = Enum(['SmoothShading', 'FlatShading', 'NoShading'], 'SmoothShading', sync=True)
-    vertexColors = Enum(['NoColors', 'FaceColors', 'VertexColors'], 'NoColors', sync=True)
-    fog = Bool(False, sync=True)
-    map = Instance(Texture, sync=True, allow_none=True, **widget_serialization)
-    lightMap = Instance(Texture, sync=True, allow_none=True, **widget_serialization)
-    specularMap = Instance(Texture, sync=True, allow_none=True, **widget_serialization)
-    envMap = Instance(Texture, sync=True, allow_none=True, **widget_serialization)
-    skinning = Bool(False, sync=True)
-    morphTargets = Bool(False, sync=True)
+    _view_name = Unicode('BasicMaterialView').tag(sync=True)
+    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _model_name = Unicode('BasicMaterialModel').tag(sync=True)
+    color = Color('white').tag(sync=True)
+    wireframe = Bool(sync=True)
+    wireframeLinewidth = CFloat(1.0).tag(sync=True)
+    wireframeLinecap = Unicode('round').tag(sync=True)
+    wireframeLinejoin = Unicode('round').tag(sync=True)
+    shading = Enum(['SmoothShading', 'FlatShading', 'NoShading'], 'SmoothShading').tag(sync=True)
+    vertexColors = Enum(['NoColors', 'FaceColors', 'VertexColors'], 'NoColors').tag(sync=True)
+    fog = Bool(sync=True)
+    map = Instance(Texture, allow_none=True).tag(sync=True, **widget_serialization)
+    lightMap = Instance(Texture, allow_none=True).tag(sync=True, **widget_serialization)
+    specularMap = Instance(Texture, allow_none=True).tag(sync=True, **widget_serialization)
+    envMap = Instance(Texture, allow_none=True).tag(sync=True, **widget_serialization)
+    skinning = Bool(sync=True)
+    morphTargets = Bool(sync=True)
+
 
 class LambertMaterial(BasicMaterial):
-    _view_name = Unicode('LambertMaterialView', sync=True)
-    ambient = Color('white', sync=True)
-    emissive = Color('black', sync=True)
-    reflectivity = CFloat(1.0, sync=True)
-    refractionRatio = CFloat(0.98, sync=True)
-    combine = Enum(['MultiplyOperation', 'MixOperation', 'AddOperation'], 'MultiplyOperation', sync=True)
-    
+    _view_name = Unicode('LambertMaterialView').tag(sync=True)
+    ambient = Color('white').tag(sync=True)
+    emissive = Color('black').tag(sync=True)
+    reflectivity = CFloat(1.0).tag(sync=True)
+    refractionRatio = CFloat(0.98).tag(sync=True)
+    combine = Enum(['MultiplyOperation', 'MixOperation', 'AddOperation'], 'MultiplyOperation').tag(sync=True)
+
+
 class PhongMaterial(BasicMaterial):
-    _view_name = Unicode('PhongMaterialView', sync=True)
-    ambient = Color('white', sync=True)
-    emissive = Color('black', sync=True)
-    specular = Color('darkgray', sync=True)
-    shininess = CFloat(30, sync=True)
-    reflectivity = CFloat(1.0, sync=True)
-    refractionRatio = CFloat(0.98, sync=True)
-    combine = Enum(['MultiplyOperation', 'MixOperation', 'AddOperation'], 'MultiplyOperation', sync=True)
-    
+    _view_name = Unicode('PhongMaterialView').tag(sync=True)
+    ambient = Color('white').tag(sync=True)
+    emissive = Color('black').tag(sync=True)
+    specular = Color('darkgray').tag(sync=True)
+    shininess = CFloat(30).tag(sync=True)
+    reflectivity = CFloat(1.0).tag(sync=True)
+    refractionRatio = CFloat(0.98).tag(sync=True)
+    combine = Enum(['MultiplyOperation', 'MixOperation', 'AddOperation'], 'MultiplyOperation').tag(sync=True)
+
+
 class DepthMaterial(Material):
-    _view_name = Unicode('DepthMaterialView', sync=True)
-    wireframe = Bool(False, sync=True)
-    wireframeLinewidth = CFloat(1.0, sync=True)
+    _view_name = Unicode('DepthMaterialView').tag(sync=True)
+    wireframe = Bool(sync=True)
+    wireframeLinewidth = CFloat(1.0).tag(sync=True)
+
 
 class _LineMaterial(Material):
     """Abstract base class for line materials"""
     _view_name = None
-    
+
+
 class LineBasicMaterial(_LineMaterial):
-    _view_name = Unicode('LineBasicMaterialView', sync=True)
-    color = Color('white', sync=True)
-    linewidth = CFloat(1.0, sync=True)
-    linecap = Unicode('round', sync=True)
-    linejoin = Unicode('round', sync=True)
-    fog = Bool(False, sync=True) 
-    vertexColors = Enum(['NoColors', 'FaceColors', 'VertexColors'], 'NoColors', sync=True)
+    _view_name = Unicode('LineBasicMaterialView').tag(sync=True)
+    color = Color('white').tag(sync=True)
+    linewidth = CFloat(1.0).tag(sync=True)
+    linecap = Unicode('round').tag(sync=True)
+    linejoin = Unicode('round').tag(sync=True)
+    fog = Bool(sync=True)
+    vertexColors = Enum(['NoColors', 'FaceColors', 'VertexColors'], 'NoColors').tag(sync=True)
+
 
 class LineDashedMaterial(_LineMaterial):
-    _view_name = Unicode('LineDashedMaterialView', sync=True)
-    color = Color('white', sync=True)
-    linewidth = CFloat(1.0, sync=True)
-    scale = CFloat(1.0, sync=True)
-    dashSize = CFloat(3.0, sync=True)
-    gapSize = CFloat(1.0, sync=True)
-    vertexColors = Enum(['NoColors', 'FaceColors', 'VertexColors'], 'NoColors', sync=True)
-    fog = Bool(False, sync=True)
+    _view_name = Unicode('LineDashedMaterialView').tag(sync=True)
+    color = Color('white').tag(sync=True)
+    linewidth = CFloat(1.0).tag(sync=True)
+    scale = CFloat(1.0).tag(sync=True)
+    dashSize = CFloat(3.0).tag(sync=True)
+    gapSize = CFloat(1.0).tag(sync=True)
+    vertexColors = Enum(['NoColors', 'FaceColors', 'VertexColors'], 'NoColors').tag(sync=True)
+    fog = Bool(sync=True)
+
 
 class NormalMaterial(Material):
-    _view_name = Unicode('NormalMaterialView', sync=True)
-    morphTargets = Bool(False, sync=True)
-    shading = Enum(['SmoothShading', 'FlatShading', 'NoShading'], 'SmoothShading', sync=True)
-    wireframe = Bool(False, sync=True)
-    wireframeLinewidth = CFloat(1.0, sync=True)
+    _view_name = Unicode('NormalMaterialView').tag(sync=True)
+    morphTargets = Bool(sync=True)
+    shading = Enum(['SmoothShading', 'FlatShading', 'NoShading'], 'SmoothShading').tag(sync=True)
+    wireframe = Bool(sync=True)
+    wireframeLinewidth = CFloat(1.0).tag(sync=True)
+
 
 class ParticleSystemMaterial(Material):
-    _view_name = Unicode('ParticleSystemMaterialView', sync=True)
-    _model_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
-    _model_name = Unicode('ParticleSystemMaterialModel', sync=True)
-    color = Color('yellow', sync=True)
-    map = Instance(Texture, sync=True, allow_none=True, **widget_serialization)
-    size = CFloat(1.0, sync=True)
-    sizeAttenuation = Bool(False, sync=True)
-    vertexColors = Bool(False, sync=True)
-    fog = Bool(False, sync=True)
+    _view_name = Unicode('ParticleSystemMaterialView').tag(sync=True)
+    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _model_name = Unicode('ParticleSystemMaterialModel').tag(sync=True)
+    color = Color('yellow').tag(sync=True)
+    map = Instance(Texture, allow_none=True).tag(sync=True, **widget_serialization)
+    size = CFloat(1.0).tag(sync=True)
+    sizeAttenuation = Bool(sync=True)
+    vertexColors = Bool(sync=True)
+    fog = Bool(sync=True)
+
 
 class ShaderMaterial(Material):
-    _view_name = Unicode('ShaderMaterialView', sync=True)
-    fragmentShader = Unicode('void main(){ }', sync=True)
-    vertexShader = Unicode('void main(){ }', sync=True)
-    morphTargets = Bool(False, sync=True)
-    lights = Bool(False, sync=True)
-    morphNormals = Bool(False, sync=True)
-    wireframe = Bool(False, sync=True)
-    vertexColors = Enum(['NoColors', 'FaceColors', 'VertexColors'], 'NoColors', sync=True)
-    skinning = Bool(False, sync=True)
-    fog = Bool(False, sync=True)
-    shading = Enum(['SmoothShading', 'FlatShading', 'NoShading'], 'SmoothShading', sync=True)
-    linewidth = CFloat(1.0, sync=True)
-    wireframeLinewidth = CFloat(1.0, sync=True)
+    _view_name = Unicode('ShaderMaterialView').tag(sync=True)
+    fragmentShader = Unicode('void main(){ }').tag(sync=True)
+    vertexShader = Unicode('void main(){ }').tag(sync=True)
+    morphTargets = Bool(sync=True)
+    lights = Bool(sync=True)
+    morphNormals = Bool(sync=True)
+    wireframe = Bool(sync=True)
+    vertexColors = Enum(['NoColors', 'FaceColors', 'VertexColors'], 'NoColors').tag(sync=True)
+    skinning = Bool(sync=True)
+    fog = Bool(sync=True)
+    shading = Enum(['SmoothShading', 'FlatShading', 'NoShading'], 'SmoothShading').tag(sync=True)
+    linewidth = CFloat(1.0).tag(sync=True)
+    wireframeLinewidth = CFloat(1.0).tag(sync=True)
+
 
 class SpriteMaterial(Material):
-    _view_name = Unicode('SpriteMaterialView', sync=True)
-    _model_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
-    _model_name = Unicode('SpriteMaterialModel', sync=True)
-    map = Instance(Texture, sync=True, allow_none=True, **widget_serialization)
-    uvScale = List(CFloat, sync=True)
-    sizeAttenuation = Bool(False, sync=True)
-    color = Color('white', sync=True)
-    uvOffset = List(CFloat, sync=True)
-    fog = Bool(False, sync=True)
-    useScreenCoordinates = Bool(False, sync=True)
-    scaleByViewport = Bool(False, sync=True)
-    alignment = List(CFloat, sync=True)
+    _view_name = Unicode('SpriteMaterialView').tag(sync=True)
+    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _model_name = Unicode('SpriteMaterialModel').tag(sync=True)
+    map = Instance(Texture, allow_none=True).tag(sync=True, **widget_serialization)
+    uvScale = List(CFloat).tag(sync=True)
+    sizeAttenuation = Bool(sync=True)
+    color = Color('white').tag(sync=True)
+    uvOffset = List(CFloat).tag(sync=True)
+    fog = Bool(sync=True)
+    useScreenCoordinates = Bool(sync=True)
+    scaleByViewport = Bool(sync=True)
+    alignment = List(CFloat).tag(sync=True)
+
 
 class Sprite(Object3d):
-    _view_name = Unicode('SpriteView', sync=True)
-    _model_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
-    _model_name = Unicode('SpriteModel', sync=True)
-    material = Instance(Material, sync=True, allow_none=True, **widget_serialization)
-    scaleToTexture = Bool(False, sync=True)
+    _view_name = Unicode('SpriteView').tag(sync=True)
+    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _model_name = Unicode('SpriteModel').tag(sync=True)
+    material = Instance(Material, allow_none=True).tag(sync=True, **widget_serialization)
+    scaleToTexture = Bool(sync=True)
 
 
 class Mesh(Object3d):
-    _view_name = Unicode('MeshView', sync=True)
-    _model_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
-    _model_name = Unicode('MeshModel', sync=True)
-    geometry = Instance(Geometry, sync=True, **widget_serialization)
-    material = Instance(Material, sync=True, **widget_serialization)
+    _view_name = Unicode('MeshView').tag(sync=True)
+    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _model_name = Unicode('MeshModel').tag(sync=True)
+    geometry = Instance(Geometry).tag(sync=True, **widget_serialization)
+    material = Instance(Material).tag(sync=True, **widget_serialization)
+
 
 class Line(Mesh):
     # don't need a custom model since we aren't introducing new custom serialized properties,
     # just making the material property a more specific instance
-    _view_name = Unicode('LineView', sync=True)
-    type = Enum(['LineStrip', 'LinePieces'], 'LineStrip', sync=True)
-    material = Instance(_LineMaterial, sync=True, **widget_serialization)
-    
+    _view_name = Unicode('LineView').tag(sync=True)
+    type = Enum(['LineStrip', 'LinePieces'], 'LineStrip').tag(sync=True)
+    material = Instance(_LineMaterial).tag(sync=True, **widget_serialization)
+
+
 class PlotMesh(Mesh):
     plot = Instance('sage.plot.plot3d.base.Graphics3d')
 
@@ -567,16 +598,15 @@ class PlotMesh(Mesh):
         if (self.type == 'object'):
             self.type = new.scenetree_json()['geometry']['type']
             self.material = self.material_from_object(new)
-        else: 
+        else:
             self.type = new.scenetree_json()['children'][0]['geometry']['type']
             self.material = self.material_from_other(new)
-        if(self.type == 'index_face_set'): 
+        if(self.type == 'index_face_set'):
             self.geometry = self.geometry_from_plot(new)
         elif(self.type == 'sphere'):
             self.geometry = self.geometry_from_sphere(new)
         elif(self.type == 'box'):
             self.geometry = self.geometry_from_box(new)
-        
 
     def material_from_object(self, p):
         # TODO: do this without scenetree_json()
@@ -618,97 +648,114 @@ class PlotMesh(Mesh):
         g.vertices = flatten(p.vertices())
         f = p.index_faces()
         f.sort(key=len)
-        faces = {k:flatten(v) for k,v in groupby(f,len)}
+        faces = {k:flatten(v) for k, v in groupby(f,len)}
         g.face3 = faces.get(3,[])
         g.face4 = faces.get(4,[])
         return g
 
+
 class Camera(Object3d):
-    _view_name = Unicode('CameraView', sync=True)
+    _view_name = Unicode('CameraView').tag(sync=True)
+
 
 class PerspectiveCamera(Camera):
-    _view_name = Unicode('PerspectiveCameraView', sync=True)
-    fov = CFloat(50.0, sync=True)
-    aspect = CFloat(6.0/4.0, sync=True)
-    near = CFloat(0.1, sync=True)
-    far = CFloat(2000.0, sync=True)
+    _view_name = Unicode('PerspectiveCameraView').tag(sync=True)
+    fov = CFloat(50.0).tag(sync=True)
+    aspect = CFloat(6.0 / 4.0).tag(sync=True)
+    near = CFloat(0.1).tag(sync=True)
+    far = CFloat(2000.0).tag(sync=True)
+
 
 class OrthographicCamera(Camera):
-    _view_name = Unicode('OrthographicCameraView', sync=True)
-    left = CFloat(-10.0, sync=True)
-    right = CFloat(10.0, sync=True)
-    top = CFloat(-10.0, sync=True)
-    bottom = CFloat(10.0, sync=True)
-    near = CFloat(0.1, sync=True)
-    far = CFloat(2000.0, sync=True)
-    
+    _view_name = Unicode('OrthographicCameraView').tag(sync=True)
+    left = CFloat(-10.0).tag(sync=True)
+    right = CFloat(10.0).tag(sync=True)
+    top = CFloat(-10.0).tag(sync=True)
+    bottom = CFloat(10.0).tag(sync=True)
+    near = CFloat(0.1).tag(sync=True)
+    far = CFloat(2000.0).tag(sync=True)
+
+
 class Scene(Object3d):
-    _view_name = Unicode('SceneView', sync=True)
-    
+    _view_name = Unicode('SceneView').tag(sync=True)
+
+
 class Effect(Widget):
-    _view_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
+    _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+
 
 class AnaglyphEffect(Effect):
-    _view_name = Unicode('AnaglyphEffectView', sync=True)
+    _view_name = Unicode('AnaglyphEffectView').tag(sync=True)
+
 
 class Renderer(Widget):
-    _view_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
-    _view_name = Unicode('RendererView', sync=True)
-    _model_module = Unicode('nbextensions/pythreejs/pythreejs', sync=True)
-    _model_name = Unicode('RendererModel', sync=True)
-    width = CInt(600, sync=True)
-    height = CInt(400, sync=True)
-    renderer_type = Enum(['webgl', 'canvas', 'auto'], 'auto', sync=True)
-    scene = Instance(Scene, sync=True, **widget_serialization)
-    camera = Instance(Camera, sync=True, **widget_serialization)
-    controls = List(Instance(Controls), sync=True, **widget_serialization)
-    effect = Instance(Effect, sync=True, allow_none=True, **widget_serialization)
-    background = Color('black', sync=True, allow_none=True)
+    _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _view_name = Unicode('RendererView').tag(sync=True)
+    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _model_name = Unicode('RendererModel').tag(sync=True)
+    width = CInt(600).tag(sync=True)
+    height = CInt(400).tag(sync=True)
+    renderer_type = Enum(['webgl', 'canvas', 'auto'], 'auto').tag(sync=True)
+    scene = Instance(Scene).tag(sync=True, **widget_serialization)
+    camera = Instance(Camera).tag(sync=True, **widget_serialization)
+    controls = List(Instance(Controls)).tag(sync=True, **widget_serialization)
+    effect = Instance(Effect, allow_none=True).tag(sync=True, **widget_serialization)
+    background = Color('black', allow_none=True).tag(sync=True)
+
 
 class Light(Object3d):
-    color = Color('white', sync=True) # could be string or number or tuple
+    color = Color('white').tag(sync=True) # could be string or number or tuple
+
 
 class AmbientLight(Light):
-    _view_name = Unicode('AmbientLight', sync=True)
+    _view_name = Unicode('AmbientLight').tag(sync=True)
+
 
 class IntensityLight(Light):
-    _view_name = Unicode('PositionLight', sync=True)
-    intensity = CFloat(1, sync=True)
+    _view_name = Unicode('PositionLight').tag(sync=True)
+    intensity = CFloat(1).tag(sync=True)
+
 
 class HemisphereLight(IntensityLight):
-    _view_name = Unicode('HemisphereLight', sync=True)
-    ground_color = Color('blue', sync=True) # could be string, number, or RGB tuple
+    _view_name = Unicode('HemisphereLight').tag(sync=True)
+    ground_color = Color('blue').tag(sync=True) # could be string, number, or RGB tuple
+
 
 class DirectionalLight(IntensityLight):
-    _view_name = Unicode('DirectionalLight', sync=True)
+    _view_name = Unicode('DirectionalLight').tag(sync=True)
+
 
 class PointLight(IntensityLight):
-    _view_name = Unicode('PointLight', sync=True)
-    distance = CFloat(10, sync=True)
+    _view_name = Unicode('PointLight').tag(sync=True)
+    distance = CFloat(10).tag(sync=True)
+
 
 class SpotLight(PointLight):
-    _view_name = Unicode('SpotLight', sync=True)
-    angle = CFloat(10, sync=True)
-    exponent = CFloat(0.5, sync=True)
+    _view_name = Unicode('SpotLight').tag(sync=True)
+    angle = CFloat(10).tag(sync=True)
+    exponent = CFloat(0.5).tag(sync=True)
+
 
 # Some helper classes and functions
 def lights_color():
     return [
-        AmbientLight(color=(0.312,0.188,0.4)),
-        DirectionalLight(position=[1,0,1], color=[0.8, 0, 0]),
-        DirectionalLight(position=[1,1,1], color=[0, 0.8, 0]),
-        DirectionalLight(position=[0,1,1], color=[0, 0, 0.8]),
-        DirectionalLight(position=[-1,-1,-1], color=[.9,.7,.9]),
+        AmbientLight(color=(0.312, 0.188, 0.4)),
+        DirectionalLight(position=[1, 0, 1], color=[0.8, 0, 0]),
+        DirectionalLight(position=[1, 1, 1], color=[0, 0.8, 0]),
+        DirectionalLight(position=[0, 1, 1], color=[0, 0, 0.8]),
+        DirectionalLight(position=[-1, -1, -1], color=[.9,.7,.9]),
     ]
+
 
 def lights_gray():
     return [
         AmbientLight(color=[.6, .6, .6]),
-        DirectionalLight(position=[0,1,1], color=[.5, .5, .5]),
-        DirectionalLight(position=[0,0,1], color=[.5, .5, .5]),
-        DirectionalLight(position=[1,1,1], color=[.5, .5, .5]),
-        DirectionalLight(position=[-1,-1,-1], color=[.7,.7,.7]),
+        DirectionalLight(position=[0, 1, 1], color=[.5, .5, .5]),
+        DirectionalLight(position=[0, 0, 1], color=[.5, .5, .5]),
+        DirectionalLight(position=[1, 1, 1], color=[.5, .5, .5]),
+        DirectionalLight(position=[-1, -1, -1], color=[.7,.7,.7]),
     ]
+
 
 class SurfaceGrid(Mesh):
     """A grid covering a surface.
@@ -717,9 +764,9 @@ class SurfaceGrid(Mesh):
     """
     # don't need a custom model since we aren't introducing new custom serialized properties,
     # just making some properties more specific instances
-    _view_name = Unicode('SurfaceGridView', sync=True)
-    geometry = Instance(SurfaceGeometry, sync=True, **widget_serialization)
-    material = Instance(_LineMaterial, sync=True, **widget_serialization)
+    _view_name = Unicode('SurfaceGridView').tag(sync=True)
+    geometry = Instance(SurfaceGeometry).tag(sync=True, **widget_serialization)
+    material = Instance(_LineMaterial).tag(sync=True, **widget_serialization)
 
 
 def make_text(text, position=(0,0,0), height=1):
@@ -734,7 +781,7 @@ def height_texture(z, colormap = 'YlGnBu_r'):
     from matplotlib import cm
     from skimage import img_as_ubyte
     import numpy as np
-    
+
     colormap = cm.get_cmap(colormap)
     im = z.copy()
     # rescale to be in [0,1], scale nan to be the smallest value

--- a/pythreejs/pythreejs.py
+++ b/pythreejs/pythreejs.py
@@ -1,30 +1,38 @@
 r"""
 Python widgets for three.js plotting
 
-In this wrapping of three.js, we try to stay close to the three.js API.  Often, the three.js documentation at http://threejs.org/docs/ helps in understanding these classes and the various constants.  This is meant to be a low-level wrapper around three.js.  We hope that others will use this foundation to build higher-level interfaces to build 3d plots.
+In this wrapping of three.js, we try to stay close to the three.js API. Often,
+the three.js documentation at http://threejs.org/docs/ helps in understanding
+these classes and the various constants.
 
-Another resource to understanding three.js decisions is the Udacity course on 3d graphics using three.js: https://www.udacity.com/course/cs291
+This is meant to be a low-level wrapper around three.js. We hope that others
+will use this foundation to build higher-level interfaces to build 3d plots.
+
+Another resource to understanding three.js decisions is the Udacity course on
+3d graphics using three.js: https://www.udacity.com/course/cs291
 """
 
 from ipywidgets import Widget, DOMWidget, widget_serialization, Color
-from traitlets import (Unicode, Int, Instance, Enum, List, Dict, Float,
-                       Any, CFloat, Bool, This, CInt, TraitType)
+from traitlets import (Unicode, Int, CInt, Instance, Enum, List, Dict, Float,
+                       CFloat, Bool)
 from math import pi, sqrt
 
 def vector3(trait_type=CFloat, default=None, **kwargs):
     if default is None:
-        default=[0, 0, 0]
+        default = [0, 0, 0]
     return List(trait_type, default_value=default, minlen=3, maxlen=3, **kwargs)
 
 def vector2(trait_type=CFloat, default=None, **kwargs):
     if default is None:
-        default=[0, 0]
+        default = [0, 0]
     return List(trait_type, default_value=default, minlen=2, maxlen=2, **kwargs)
 
 
 class Texture(Widget):
     _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
     _view_name = Unicode('TextureView').tag(sync=True)
+    _model_name = Unicode('TextureModel').tag(sync=True)
 
 
 class ImageTexture(Texture):
@@ -33,6 +41,8 @@ class ImageTexture(Texture):
     The imageuri can be a data url or a web url.
     """
     _view_name = Unicode('ImageTextureView').tag(sync=True)
+    _model_name = Unicode('ImageTextureModel').tag(sync=True)
+
     imageuri = Unicode().tag(sync=True)
 
 
@@ -42,26 +52,35 @@ class DataTexture(Texture):
     See http://threejs.org/docs/#Reference/Textures/DataTexture.
     """
     _view_name = Unicode('DataTextureView').tag(sync=True)
+    _model_name = Unicode('DataTextureModel').tag(sync=True)
+
     data = List(CInt).tag(sync=True)
-    format = Enum(['RGBAFormat', 'AlphaFormat', 'RGBFormat', 'LuminanceFormat', 'LuminanceAlphaFormat'],
-            'RGBAFormat').tag(sync=True)
+    format = Enum(['RGBAFormat', 'AlphaFormat', 'RGBFormat', 'LuminanceFormat',
+                   'LuminanceAlphaFormat'], 'RGBAFormat').tag(sync=True)
     width = CInt(256).tag(sync=True)
     height = CInt(256).tag(sync=True)
-    type = Enum(['UnsignedByteType', 'ByteType', 'ShortType', 'UnsignedShortType', 'IntType',
-                 'UnsignedIntType', 'FloatType', 'UnsignedShort4444Type', 'UnsignedShort5551Type',
+    type = Enum(['UnsignedByteType', 'ByteType', 'ShortType',
+                 'UnsignedShortType', 'IntType', 'UnsignedIntType',
+                 'FloatType', 'UnsignedShort4444Type', 'UnsignedShort5551Type',
                  'UnsignedShort565Type'], 'UnsignedByteType').tag(sync=True)
-    mapping = Enum(['UVMapping', 'CubeReflectionMapping', 'CubeRefractionMapping', 'SphericalReflectionMapping',
+    mapping = Enum(['UVMapping', 'CubeReflectionMapping',
+                    'CubeRefractionMapping', 'SphericalReflectionMapping',
                     'SphericalRefractionMapping'], 'UVMapping').tag(sync=True)
-    wrapS = Enum(['ClampToEdgeWrapping', 'RepeatWrapping', 'MirroredRepeatWrapping'], 'ClampToEdgeWrapping').tag(sync=True)
-    wrapT = Enum(['ClampToEdgeWrapping', 'RepeatWrapping', 'MirroredRepeatWrapping'], 'ClampToEdgeWrapping').tag(sync=True)
+    wrapS = Enum(['ClampToEdgeWrapping', 'RepeatWrapping', 'MirroredRepeatWrapping'],
+                 'ClampToEdgeWrapping').tag(sync=True)
+    wrapT = Enum(['ClampToEdgeWrapping', 'RepeatWrapping', 'MirroredRepeatWrapping'],
+                 'ClampToEdgeWrapping').tag(sync=True)
     magFilter = Enum(['LinearFilter', 'NearestFilter'], 'LinearFilter').tag(sync=True)
-    minFilter = Enum(['NearestFilter', 'NearestMipMapNearestFilter', 'NearestMipMapLinearFilter',
-                      'LinearFilter', 'LinearMipMapNearestFilter'], 'NearestFilter').tag(sync=True)
+    minFilter = Enum(['NearestFilter', 'NearestMipMapNearestFilter',
+                      'NearestMipMapLinearFilter', 'LinearFilter',
+                      'LinearMipMapNearestFilter'], 'NearestFilter').tag(sync=True)
     anisotropy = CInt(1).tag(sync=True)
 
 
 class TextTexture(Texture):
     _view_name = Unicode('TextTextureView').tag(sync=True)
+    _model_name = Unicode('TextTextureModel').tag(sync=True)
+
     fontFace = Unicode('Arial').tag(sync=True)
     size = CInt(12).tag(sync=True)
     color = Color('black').tag(sync=True)
@@ -74,17 +93,19 @@ class Object3d(Widget):
     If matrix is not None, it overrides the position, rotation, scale, and up variables.
     """
     _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
-    _view_name = Unicode('Object3dView').tag(sync=True)
     _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _view_name = Unicode('Object3dView').tag(sync=True)
     _model_name = Unicode('Object3dModel').tag(sync=True)
+
     position = vector3(CFloat).tag(sync=True)
-    quaternion = List(CFloat).tag(sync=True) # [x,y,z,w]
+    quaternion = List(CFloat).tag(sync=True)  # [x,y,z,w]
     scale = vector3(CFloat, [1, 1, 1]).tag(sync=True)
     up = vector3(CFloat, [0, 1, 0]).tag(sync=True)
     visible = Bool(True).tag(sync=True)
-    castShadow = Bool(sync=True)
-    receiveShadow = Bool(sync=True)
-    # FYI, this matrix has the translation in the 4th row, which is is the
+    castShadow = Bool().tag(sync=True)
+    receiveShadow = Bool().tag(sync=True)
+
+    # This matrix has the translation in the 4th row, which is is the
     # transpose of Sage's transformation matrices
     # TODO: figure out how to get a list of instances of Object3d
     children = List().tag(sync=True, **widget_serialization)
@@ -97,7 +118,7 @@ class Object3d(Widget):
         self.scale = [self.vector_length(x),
                       self.vector_length(y),
                       self.vector_length(z)]
-        m=[]
+        m = []
         m.extend(x)
         m.extend(y)
         m.extend(z)
@@ -116,18 +137,18 @@ class Object3d(Widget):
         y = m[3:6]
         z = m[6:9]
         trace = x[0] + y[1] + z[2]
-        if (trace>0):
-            s = 0.5/sqrt(trace+1)
-            self.quaternion = [(y[2]-z[1])*s, (z[0]-x[2])*s, (x[1]-y[0])*s, 0.25/s]
-        elif (x[0]>y[1] and x[0]>z[2]):
-            s = 2.0*sqrt(1.0+x[0]-y[1]-z[2])
-            self.quaternion = [0.25*s, (y[0]+x[1])/s, (z[0]+x[2])/s, (y[2]-z[1])/s]
-        elif (y[1]>z[2]):
-            s = 2.0*sqrt(1.0+y[1]-x[0]-z[2])
-            self.quaternion = [(y[0]+x[1])/s, 0.25*s, (z[1]+y[2])/s, (z[0]-x[2])/s]
+        if (trace > 0):
+            s = 0.5 / sqrt(trace + 1)
+            self.quaternion = [(y[2] - z[1]) * s, (z[0] - x[2]) * s, (x[1] - y[0]) * s, 0.25 / s]
+        elif (x[0] > y[1] and x[0] > z[2]):
+            s = 2.0 * sqrt(1.0 + x[0] - y[1] - z[2])
+            self.quaternion = [0.25 * s, (y[0] + x[1]) / s, (z[0] + x[2]) / s, (y[2] - z[1]) / s]
+        elif (y[1] > z[2]):
+            s = 2.0 * sqrt(1.0 + y[1] - x[0] - z[2])
+            self.quaternion = [(y[0] + x[1]) / s, 0.25 * s, (z[1] + y[2]) / s, (z[0] - x[2]) / s]
         else:
-            s = 2.0*sqrt(1.0+z[2]-x[0]-y[1])
-            self.quaternion = [(z[0]+x[2])/s, (z[1]+y[2])/s, 0.25*s, (x[1]-y[0])/s]
+            s = 2.0 * sqrt(1.0 + z[2] - x[0] - y[1])
+            self.quaternion = [(z[0] + x[2]) / s, (z[1] + y[2]) / s, 0.25 * s, (x[1] - y[0]) / s]
 
     def vector_length(self, x):
         return sqrt(x[0] * x[0] + x[1] * x[1] + x[2] * x[2])
@@ -146,24 +167,26 @@ class Object3d(Widget):
     def normalize(self, x):
         return self.vector_divide_scalar(self.vector_length(x),x)
 
-    def vector_cross(self, x, y): # x X y
-        return [x[1]*y[2]-x[2]*y[1], x[2]*y[0]-x[0]*y[2], x[0]*y[1]-x[1]*y[0]]
+    def vector_cross(self, x, y):  # x X y
+        return [x[1] * y[2] - x[2] * y[1],
+                x[2] * y[0] - x[0] * y[2],
+                x[0] * y[1] - x[1] * y[0]]
 
     def look_at(self, eye, target):
         z = self.normalize([eye[0] - target[0],
                             eye[1] - target[1],
                             eye[2] - target[2]])  # eye - target
 
-        if (self.vector_length(z)==0):
-            z[2]=1
+        if (self.vector_length(z) == 0):
+            z[2] = 1
         x = self.normalize(self.vector_cross(self.up, z))
 
-        if (self.vector_length(x)==0):
+        if (self.vector_length(x) == 0):
             z[0] += 0.0001
             x = self.normalize(self.vector_cross(self.up, z))
 
         y = self.vector_cross(z, x)
-        m=[]
+        m = []
         m.extend(x)
         m.extend(y)
         m.extend(z)
@@ -172,34 +195,41 @@ class Object3d(Widget):
 
 class ScaledObject(Object3d):
     """
-    This object's matrix will be scaled every time the camera is adjusted, so that the object is always the same
-    size in the viewport.
+    This object's matrix will be scaled every time the camera is adjusted, so
+    that the object is always the same size in the viewport.
 
     The idea is that it is the parent for objects you want to maintain the same scale.
     """
     _view_name = Unicode('ScaledObjectView').tag(sync=True)
+    _model_name = Unicode('ScaledObjectModel').tag(sync=True)
 
 
 class Controls(Widget):
     _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
-    _view_name = Unicode('ControlsView').tag(sync=True)
     _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _view_name = Unicode('ControlsView').tag(sync=True)
     _model_name = Unicode('ControlsModel').tag(sync=True)
+
     controlling = Instance(Object3d, allow_none=True).tag(sync=True, **widget_serialization)
 
 
 class OrbitControls(Controls):
     _view_name = Unicode('OrbitControlsView').tag(sync=True)
+    _model_name = Unicode('OrbitControlsModel').tag(sync=True)
+
     target = vector3(CFloat).tag(sync=True)
 
 
 class TrackballControls(Controls):
     _view_name = Unicode('TrackballControlsView').tag(sync=True)
+    _model_name = Unicode('TrackballControlsModel').tag(sync=True)
+
     target = vector3(CFloat).tag(sync=True)
 
 
 class FlyControls(Controls):
     _view_name = Unicode('FlyControlsView').tag(sync=True)
+    _model_name = Unicode('FlyControlsModel').tag(sync=True)
 
     forward_speed = Float().tag(sync=True)
     lateral_speed = Float().tag(sync=True)
@@ -210,8 +240,9 @@ class FlyControls(Controls):
 
 
 class Picker(Controls):
-    _view_name  = Unicode('PickerView').tag(sync=True)
-    _model_name  = Unicode('PickerModel').tag(sync=True)
+    _view_name = Unicode('PickerView').tag(sync=True)
+    _model_name = Unicode('PickerModel').tag(sync=True)
+
     event = Unicode('click').tag(sync=True)
     root = Instance(Object3d, allow_none=True).tag(sync=True, **widget_serialization)
     picked = List(Dict).tag(sync=True)
@@ -221,17 +252,21 @@ class Picker(Controls):
     face = vector3(CInt).tag(sync=True)
     faceNormal = vector3(CFloat).tag(sync=True)
     faceVertices = List(vector3()).tag(sync=True)
-    faceIndex = CInt(sync=True)
-    all = Bool(sync=True)
+    faceIndex = CInt().tag(sync=True)
+    all = Bool().tag(sync=True)
 
 
 class Geometry(Widget):
     _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
     _view_name = Unicode('GeometryView').tag(sync=True)
+    _model_name = Unicode('GeometryModel').tag(sync=True)
 
 
 class PlainGeometry(Geometry):
     _view_name = Unicode('PlainGeometryView').tag(sync=True)
+    _model_name = Unicode('PlainGeometryModel').tag(sync=True)
+
     vertices = List(vector3(CFloat)).tag(sync=True)
     colors = List(Color).tag(sync=True)
     faces = List(List(CFloat)).tag(sync=True)
@@ -240,21 +275,27 @@ class PlainGeometry(Geometry):
 
 class SphereGeometry(Geometry):
     _view_name = Unicode('SphereGeometryView').tag(sync=True)
+    _model_name = Unicode('SphereGeometryModel').tag(sync=True)
+
     radius = CFloat(1).tag(sync=True)
 
 
 class CylinderGeometry(Geometry):
     _view_name = Unicode('CylinderGeometryView').tag(sync=True)
+    _model_name = Unicode('CylinderGeometryModel').tag(sync=True)
+
     radiusTop = CFloat(1).tag(sync=True)
     radiusBottom = CFloat(1).tag(sync=True)
     height = CFloat(1).tag(sync=True)
     radiusSegments = CFloat(20).tag(sync=True)
     heightSegments = CFloat(1).tag(sync=True)
-    openEnded = Bool(sync=True)
+    openEnded = Bool().tag(sync=True)
 
 
 class BoxGeometry(Geometry):
     _view_name = Unicode('BoxGeometryView').tag(sync=True)
+    _model_name = Unicode('BoxGeometryModel').tag(sync=True)
+
     width = CFloat(1).tag(sync=True)
     height = CFloat(1).tag(sync=True)
     depth = CFloat(1).tag(sync=True)
@@ -265,43 +306,55 @@ class BoxGeometry(Geometry):
 
 class CircleGeometry(Geometry):
     _view_name = Unicode('CircleGeometryView').tag(sync=True)
+    _model_name = Unicode('CircleGeometryModel').tag(sync=True)
+
     radius = CFloat(1).tag(sync=True)
     segments = CFloat(8).tag(sync=True)
     thetaStart = CFloat(0).tag(sync=True)
-    thetaLength = CFloat(2*pi).tag(sync=True)
+    thetaLength = CFloat(2 * pi).tag(sync=True)
 
 
 class LatheGeometry(Geometry):
     _view_name = Unicode('LatheGeometryView').tag(sync=True)
+    _model_name = Unicode('LatheGeometryModel').tag(sync=True)
+
     points = List(vector3()).tag(sync=True)
     segments = CInt(12).tag(sync=True)
     phiStart = CFloat(0).tag(sync=True)
-    phiLength = CFloat(2*pi).tag(sync=True)
+    phiLength = CFloat(2 * pi).tag(sync=True)
 
 
 class TubeGeometry(Geometry):
     _view_name = Unicode('TubeGeometryView').tag(sync=True)
+    _model_name = Unicode('TubeGeometryModel').tag(sync=True)
+
     path = List(vector3()).tag(sync=True)
     segments = CInt(64).tag(sync=True)
     radius = CFloat(1).tag(sync=True)
     radialSegments = CFloat(8).tag(sync=True)
-    closed = Bool(sync=True)
+    closed = Bool().tag(sync=True)
 
 
 class IcosahedronGeometry(Geometry):
     _view_name = Unicode('IcosahedronGeometryView').tag(sync=True)
+    _model_name = Unicode('IcosahedronGeometryModel').tag(sync=True)
+
     radius = CFloat(1).tag(sync=True)
     detail = CFloat(0).tag(sync=True)
 
 
 class OctahedronGeometry(Geometry):
     _view_name = Unicode('OctahedronGeometryView').tag(sync=True)
+    _model_name = Unicode('OctahedronGeometryModel').tag(sync=True)
+
     radius = CFloat(1).tag(sync=True)
     detail = CFloat(0).tag(sync=True)
 
 
 class PlaneGeometry(Geometry):
     _view_name = Unicode('PlaneGeometryView').tag(sync=True)
+    _model_name = Unicode('PlaneGeometryModel').tag(sync=True)
+
     width = CFloat(1).tag(sync=True)
     height = CFloat(1).tag(sync=True)
     widthSegments = CFloat(1).tag(sync=True)
@@ -310,21 +363,27 @@ class PlaneGeometry(Geometry):
 
 class TetrahedronGeometry(Geometry):
     _view_name = Unicode('TetrahedronGeometryView').tag(sync=True)
+    _model_name = Unicode('TetrahedronGeometryModel').tag(sync=True)
+
     radius = CFloat(1).tag(sync=True)
     detail = CFloat(0).tag(sync=True)
 
 
 class TorusGeometry(Geometry):
     _view_name = Unicode('TorusGeometryView').tag(sync=True)
+    _model_name = Unicode('TorusGeometryModel').tag(sync=True)
+
     radius = CFloat(1).tag(sync=True)
     tube = CFloat(1).tag(sync=True)
     radialSegments = CFloat(1).tag(sync=True)
     tubularSegments = CFloat(1).tag(sync=True)
-    arc = CFloat(pi*2).tag(sync=True)
+    arc = CFloat(pi * 2).tag(sync=True)
 
 
 class TorusKnotGeometry(Geometry):
     _view_name = Unicode('TorusKnotGeometryView').tag(sync=True)
+    _model_name = Unicode('TorusKnotGeometryModel').tag(sync=True)
+
     radius = CFloat(1).tag(sync=True)
     tube = CFloat(1).tag(sync=True)
     radialSegments = CFloat(10).tag(sync=True)
@@ -336,6 +395,8 @@ class TorusKnotGeometry(Geometry):
 
 class PolyhedronGeometry(Geometry):
     _view_name = Unicode('PolyhedronGeometryView').tag(sync=True)
+    _model_name = Unicode('PolyhedronGeometryModel').tag(sync=True)
+
     radius = CFloat(1).tag(sync=True)
     detail = CInt(0).tag(sync=True)
     vertices = List(List(CFloat)).tag(sync=True)
@@ -344,12 +405,14 @@ class PolyhedronGeometry(Geometry):
 
 class RingGeometry(Geometry):
     _view_name = Unicode('RingGeometryView').tag(sync=True)
+    _model_name = Unicode('RingGeometryModel').tag(sync=True)
+
     innerRadius = CFloat(1.0).tag(sync=True)
     outerRadius = CFloat(3.0).tag(sync=True)
     thetaSegments = CInt(8).tag(sync=True)
     phiSegments = CInt(8).tag(sync=True)
     thetaStart = CFloat(0).tag(sync=True)
-    thetaLength = CFloat(pi*2).tag(sync=True)
+    thetaLength = CFloat(pi * 2).tag(sync=True)
 
 
 class SurfaceGeometry(Geometry):
@@ -357,7 +420,9 @@ class SurfaceGeometry(Geometry):
     A regular grid with heights
     """
     _view_name = Unicode('SurfaceGeometryView').tag(sync=True)
-    z = List(CFloat, [0]*100).tag(sync=True)
+    _model_name = Unicode('SurfaceGeometryModel').tag(sync=True)
+
+    z = List(CFloat, [0] * 100).tag(sync=True)
     width = CInt(10).tag(sync=True)
     height = CInt(10).tag(sync=True)
     width_segments = CInt(10).tag(sync=True)
@@ -369,6 +434,8 @@ class FaceGeometry(Geometry):
     List of vertices and faces
     """
     _view_name = Unicode('FaceGeometryView').tag(sync=True)
+    _model_name = Unicode('FaceGeometryModel').tag(sync=True)
+
     vertices = List(CFloat).tag(sync=True)  # [x0, y0, z0, x1, y1, z1, x2, y2, z2, ...]
     face3 = List(CInt).tag(sync=True)  # [v0,v1,v2, v0,v1,v2, v0,v1,v2, ...]
     face4 = List(CInt).tag(sync=True)  # [v0,v1,v2,v3, v0,v1,v2,v3, v0,v1,v2,v3, ...]
@@ -377,25 +444,35 @@ class FaceGeometry(Geometry):
 
 class ParametricGeometry(Geometry):
     _view_name = Unicode('ParametricGeometryView').tag(sync=True)
+    _model_name = Unicode('ParametricGeometryModel').tag(sync=True)
+
     func = Unicode(sync=True)
     slices = CInt(105).tag(sync=True)
-    stacks = CInt(105,sync=True)
+    stacks = CInt(105).tag(sync=True)
 
 
 class Material(Widget):
     _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
     _view_name = Unicode('MaterialView').tag(sync=True)
+    _model_name = Unicode('MaterialModel').tag(sync=True)
+
     # id = TODO
     name = Unicode(sync=True)
     side = Enum(['FrontSide', 'BackSide', 'DoubleSide'], 'DoubleSide').tag(sync=True)
     opacity = CFloat(1.0).tag(sync=True)
-    transparent = Bool(sync=True)
-    blending = Enum(['NoBlending', 'NormalBlending', 'AdditiveBlending', 'SubtractiveBlending', 'MultiplyBlending',
-                    'CustomBlending'], 'NormalBlending').tag(sync=True)
-    blendSrc = Enum(['ZeroFactor', 'OneFactor', 'SrcColorFactor', 'OneMinusSrcColorFactor', 'SrcAlphaFactor',
-                    'OneMinusSrcAlphaFactor', 'DstAlphaFactor', 'OneMinusDstAlphaFactor'], 'SrcAlphaFactor').tag(sync=True)
-    blendDst = Enum(['DstColorFactor', 'OneMinusDstColorFactor', 'SrcAlphaSaturateFactor'], 'OneMinusDstColorFactor').tag(sync=True)
-    blendEquation = Enum(['AddEquation', 'SubtractEquation', 'ReverseSubtractEquation'], 'AddEquation').tag(sync=True)
+    transparent = Bool().tag(sync=True)
+    blending = Enum(['NoBlending', 'NormalBlending', 'AdditiveBlending',
+                     'SubtractiveBlending', 'MultiplyBlending',
+                     'CustomBlending'], 'NormalBlending').tag(sync=True)
+    blendSrc = Enum(['ZeroFactor', 'OneFactor', 'SrcColorFactor',
+                     'OneMinusSrcColorFactor', 'SrcAlphaFactor',
+                     'OneMinusSrcAlphaFactor', 'DstAlphaFactor',
+                     'OneMinusDstAlphaFactor'], 'SrcAlphaFactor').tag(sync=True)
+    blendDst = Enum(['DstColorFactor', 'OneMinusDstColorFactor',
+                     'SrcAlphaSaturateFactor'], 'OneMinusDstColorFactor').tag(sync=True)
+    blendEquation = Enum(['AddEquation', 'SubtractEquation',
+                          'ReverseSubtractEquation'], 'AddEquation').tag(sync=True)
     depthTest = Bool(True).tag(sync=True)
     depthWrite = Bool(True).tag(sync=True)
     polygonOffset = Bool(True).tag(sync=True)
@@ -409,107 +486,122 @@ class Material(Widget):
 
 class BasicMaterial(Material):
     _view_name = Unicode('BasicMaterialView').tag(sync=True)
-    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
     _model_name = Unicode('BasicMaterialModel').tag(sync=True)
+
     color = Color('white').tag(sync=True)
-    wireframe = Bool(sync=True)
+    wireframe = Bool().tag(sync=True)
     wireframeLinewidth = CFloat(1.0).tag(sync=True)
     wireframeLinecap = Unicode('round').tag(sync=True)
     wireframeLinejoin = Unicode('round').tag(sync=True)
     shading = Enum(['SmoothShading', 'FlatShading', 'NoShading'], 'SmoothShading').tag(sync=True)
     vertexColors = Enum(['NoColors', 'FaceColors', 'VertexColors'], 'NoColors').tag(sync=True)
-    fog = Bool(sync=True)
+    fog = Bool().tag(sync=True)
     map = Instance(Texture, allow_none=True).tag(sync=True, **widget_serialization)
     lightMap = Instance(Texture, allow_none=True).tag(sync=True, **widget_serialization)
     specularMap = Instance(Texture, allow_none=True).tag(sync=True, **widget_serialization)
     envMap = Instance(Texture, allow_none=True).tag(sync=True, **widget_serialization)
-    skinning = Bool(sync=True)
-    morphTargets = Bool(sync=True)
+    skinning = Bool().tag(sync=True)
+    morphTargets = Bool().tag(sync=True)
 
 
 class LambertMaterial(BasicMaterial):
     _view_name = Unicode('LambertMaterialView').tag(sync=True)
+    _model_name = Unicode('LambertMaterialModel').tag(sync=True)
+
     ambient = Color('white').tag(sync=True)
     emissive = Color('black').tag(sync=True)
     reflectivity = CFloat(1.0).tag(sync=True)
     refractionRatio = CFloat(0.98).tag(sync=True)
-    combine = Enum(['MultiplyOperation', 'MixOperation', 'AddOperation'], 'MultiplyOperation').tag(sync=True)
+    combine = Enum(['MultiplyOperation', 'MixOperation', 'AddOperation'],
+                   'MultiplyOperation').tag(sync=True)
 
 
 class PhongMaterial(BasicMaterial):
     _view_name = Unicode('PhongMaterialView').tag(sync=True)
+    _model_name = Unicode('PhongMaterialModel').tag(sync=True)
+
     ambient = Color('white').tag(sync=True)
     emissive = Color('black').tag(sync=True)
     specular = Color('darkgray').tag(sync=True)
     shininess = CFloat(30).tag(sync=True)
     reflectivity = CFloat(1.0).tag(sync=True)
     refractionRatio = CFloat(0.98).tag(sync=True)
-    combine = Enum(['MultiplyOperation', 'MixOperation', 'AddOperation'], 'MultiplyOperation').tag(sync=True)
+    combine = Enum(['MultiplyOperation', 'MixOperation', 'AddOperation'],
+                   'MultiplyOperation').tag(sync=True)
 
 
 class DepthMaterial(Material):
     _view_name = Unicode('DepthMaterialView').tag(sync=True)
-    wireframe = Bool(sync=True)
+    _model_name = Unicode('DepthMaterialModel').tag(sync=True)
+
+    wireframe = Bool().tag(sync=True)
     wireframeLinewidth = CFloat(1.0).tag(sync=True)
 
 
 class _LineMaterial(Material):
     """Abstract base class for line materials"""
-    _view_name = None
 
 
 class LineBasicMaterial(_LineMaterial):
     _view_name = Unicode('LineBasicMaterialView').tag(sync=True)
+    _model_name = Unicode('LineBasicMaterialModel').tag(sync=True)
+
     color = Color('white').tag(sync=True)
     linewidth = CFloat(1.0).tag(sync=True)
     linecap = Unicode('round').tag(sync=True)
     linejoin = Unicode('round').tag(sync=True)
-    fog = Bool(sync=True)
+    fog = Bool().tag(sync=True)
     vertexColors = Enum(['NoColors', 'FaceColors', 'VertexColors'], 'NoColors').tag(sync=True)
 
 
 class LineDashedMaterial(_LineMaterial):
     _view_name = Unicode('LineDashedMaterialView').tag(sync=True)
+    _model_name = Unicode('LineDashedMaterialModel').tag(sync=True)
+
     color = Color('white').tag(sync=True)
     linewidth = CFloat(1.0).tag(sync=True)
     scale = CFloat(1.0).tag(sync=True)
     dashSize = CFloat(3.0).tag(sync=True)
     gapSize = CFloat(1.0).tag(sync=True)
     vertexColors = Enum(['NoColors', 'FaceColors', 'VertexColors'], 'NoColors').tag(sync=True)
-    fog = Bool(sync=True)
+    fog = Bool().tag(sync=True)
 
 
 class NormalMaterial(Material):
     _view_name = Unicode('NormalMaterialView').tag(sync=True)
-    morphTargets = Bool(sync=True)
+    _model_name = Unicode('NormalMaterialModel').tag(sync=True)
+
+    morphTargets = Bool().tag(sync=True)
     shading = Enum(['SmoothShading', 'FlatShading', 'NoShading'], 'SmoothShading').tag(sync=True)
-    wireframe = Bool(sync=True)
+    wireframe = Bool().tag(sync=True)
     wireframeLinewidth = CFloat(1.0).tag(sync=True)
 
 
 class ParticleSystemMaterial(Material):
     _view_name = Unicode('ParticleSystemMaterialView').tag(sync=True)
-    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
     _model_name = Unicode('ParticleSystemMaterialModel').tag(sync=True)
+
     color = Color('yellow').tag(sync=True)
     map = Instance(Texture, allow_none=True).tag(sync=True, **widget_serialization)
     size = CFloat(1.0).tag(sync=True)
-    sizeAttenuation = Bool(sync=True)
-    vertexColors = Bool(sync=True)
-    fog = Bool(sync=True)
+    sizeAttenuation = Bool().tag(sync=True)
+    vertexColors = Bool().tag(sync=True)
+    fog = Bool().tag(sync=True)
 
 
 class ShaderMaterial(Material):
     _view_name = Unicode('ShaderMaterialView').tag(sync=True)
+    _model_name = Unicode('ShaderMaterialModel').tag(sync=True)
+
     fragmentShader = Unicode('void main(){ }').tag(sync=True)
     vertexShader = Unicode('void main(){ }').tag(sync=True)
-    morphTargets = Bool(sync=True)
-    lights = Bool(sync=True)
-    morphNormals = Bool(sync=True)
-    wireframe = Bool(sync=True)
+    morphTargets = Bool().tag(sync=True)
+    lights = Bool().tag(sync=True)
+    morphNormals = Bool().tag(sync=True)
+    wireframe = Bool().tag(sync=True)
     vertexColors = Enum(['NoColors', 'FaceColors', 'VertexColors'], 'NoColors').tag(sync=True)
-    skinning = Bool(sync=True)
-    fog = Bool(sync=True)
+    skinning = Bool().tag(sync=True)
+    fog = Bool().tag(sync=True)
     shading = Enum(['SmoothShading', 'FlatShading', 'NoShading'], 'SmoothShading').tag(sync=True)
     linewidth = CFloat(1.0).tag(sync=True)
     wireframeLinewidth = CFloat(1.0).tag(sync=True)
@@ -517,39 +609,39 @@ class ShaderMaterial(Material):
 
 class SpriteMaterial(Material):
     _view_name = Unicode('SpriteMaterialView').tag(sync=True)
-    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
     _model_name = Unicode('SpriteMaterialModel').tag(sync=True)
+
     map = Instance(Texture, allow_none=True).tag(sync=True, **widget_serialization)
     uvScale = List(CFloat).tag(sync=True)
-    sizeAttenuation = Bool(sync=True)
+    sizeAttenuation = Bool().tag(sync=True)
     color = Color('white').tag(sync=True)
     uvOffset = List(CFloat).tag(sync=True)
-    fog = Bool(sync=True)
-    useScreenCoordinates = Bool(sync=True)
-    scaleByViewport = Bool(sync=True)
+    fog = Bool().tag(sync=True)
+    useScreenCoordinates = Bool().tag(sync=True)
+    scaleByViewport = Bool().tag(sync=True)
     alignment = List(CFloat).tag(sync=True)
 
 
 class Sprite(Object3d):
     _view_name = Unicode('SpriteView').tag(sync=True)
-    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
     _model_name = Unicode('SpriteModel').tag(sync=True)
+
     material = Instance(Material, allow_none=True).tag(sync=True, **widget_serialization)
-    scaleToTexture = Bool(sync=True)
+    scaleToTexture = Bool().tag(sync=True)
 
 
 class Mesh(Object3d):
     _view_name = Unicode('MeshView').tag(sync=True)
-    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
     _model_name = Unicode('MeshModel').tag(sync=True)
+
     geometry = Instance(Geometry).tag(sync=True, **widget_serialization)
     material = Instance(Material).tag(sync=True, **widget_serialization)
 
 
 class Line(Mesh):
-    # don't need a custom model since we aren't introducing new custom serialized properties,
-    # just making the material property a more specific instance
     _view_name = Unicode('LineView').tag(sync=True)
+    _model_name = Unicode('LineModel').tag(sync=True)
+
     type = Enum(['LineStrip', 'LinePieces'], 'LineStrip').tag(sync=True)
     material = Instance(_LineMaterial).tag(sync=True, **widget_serialization)
 
@@ -612,7 +704,7 @@ class PlotMesh(Mesh):
         g.vertices = flatten(p.vertices())
         f = p.index_faces()
         f.sort(key=len)
-        faces = {k:flatten(v) for k, v in groupby(f,len)}
+        faces = { k:flatten(v) for k, v in groupby(f, len) }
         g.face3 = faces.get(3,[])
         g.face4 = faces.get(4,[])
         return g
@@ -620,10 +712,13 @@ class PlotMesh(Mesh):
 
 class Camera(Object3d):
     _view_name = Unicode('CameraView').tag(sync=True)
+    _model_name = Unicode('CameraModel').tag(sync=True)
 
 
 class PerspectiveCamera(Camera):
     _view_name = Unicode('PerspectiveCameraView').tag(sync=True)
+    _model_name = Unicode('PerspectiveCameraModel').tag(sync=True)
+
     fov = CFloat(50.0).tag(sync=True)
     aspect = CFloat(6.0 / 4.0).tag(sync=True)
     near = CFloat(0.1).tag(sync=True)
@@ -632,6 +727,8 @@ class PerspectiveCamera(Camera):
 
 class OrthographicCamera(Camera):
     _view_name = Unicode('OrthographicCameraView').tag(sync=True)
+    _model_name = Unicode('OrthographicCameraModel').tag(sync=True)
+
     left = CFloat(-10.0).tag(sync=True)
     right = CFloat(10.0).tag(sync=True)
     top = CFloat(-10.0).tag(sync=True)
@@ -642,21 +739,25 @@ class OrthographicCamera(Camera):
 
 class Scene(Object3d):
     _view_name = Unicode('SceneView').tag(sync=True)
+    _model_name = Unicode('SceneModel').tag(sync=True)
 
 
 class Effect(Widget):
     _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
 
 
 class AnaglyphEffect(Effect):
     _view_name = Unicode('AnaglyphEffectView').tag(sync=True)
+    _model_name = Unicode('AnaglyphEffectModel').tag(sync=True)
 
 
 class Renderer(DOMWidget):
     _view_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
-    _view_name = Unicode('RendererView').tag(sync=True)
     _model_module = Unicode('nbextensions/pythreejs/pythreejs').tag(sync=True)
+    _view_name = Unicode('RendererView').tag(sync=True)
     _model_name = Unicode('RendererModel').tag(sync=True)
+
     width = CInt(600).tag(sync=True)
     height = CInt(400).tag(sync=True)
     renderer_type = Enum(['webgl', 'canvas', 'auto'], 'auto').tag(sync=True)
@@ -668,34 +769,44 @@ class Renderer(DOMWidget):
 
 
 class Light(Object3d):
-    color = Color('white').tag(sync=True) # could be string or number or tuple
+    color = Color('white').tag(sync=True)  # could be string or number or tuple
 
 
 class AmbientLight(Light):
     _view_name = Unicode('AmbientLight').tag(sync=True)
+    _model_name = Unicode('AmbientLightModel').tag(sync=True)
 
 
 class IntensityLight(Light):
     _view_name = Unicode('PositionLight').tag(sync=True)
+    _model_name = Unicode('PositionLightModel').tag(sync=True)
+
     intensity = CFloat(1).tag(sync=True)
 
 
 class HemisphereLight(IntensityLight):
     _view_name = Unicode('HemisphereLight').tag(sync=True)
+    _model_name = Unicode('HemisphereLightModel').tag(sync=True)
+
     ground_color = Color('blue').tag(sync=True) # could be string, number, or RGB tuple
 
 
 class DirectionalLight(IntensityLight):
     _view_name = Unicode('DirectionalLight').tag(sync=True)
+    _model_name = Unicode('DirectionalLightModel').tag(sync=True)
 
 
 class PointLight(IntensityLight):
     _view_name = Unicode('PointLight').tag(sync=True)
+    _model_name = Unicode('PointLightModel').tag(sync=True)
+
     distance = CFloat(10).tag(sync=True)
 
 
 class SpotLight(PointLight):
     _view_name = Unicode('SpotLight').tag(sync=True)
+    _model_name = Unicode('SpotLightModel').tag(sync=True)
+
     angle = CFloat(10).tag(sync=True)
     exponent = CFloat(0.5).tag(sync=True)
 
@@ -726,19 +837,19 @@ class SurfaceGrid(Mesh):
 
     This will draw a line mesh overlaying the SurfaceGeometry.
     """
-    # don't need a custom model since we aren't introducing new custom serialized properties,
-    # just making some properties more specific instances
     _view_name = Unicode('SurfaceGridView').tag(sync=True)
+    _model_name = Unicode('SurfaceGridModel').tag(sync=True)
+
     geometry = Instance(SurfaceGeometry).tag(sync=True, **widget_serialization)
     material = Instance(_LineMaterial).tag(sync=True, **widget_serialization)
 
 
-def make_text(text, position=(0,0,0), height=1):
+def make_text(text, position=(0, 0, 0), height=1):
     """
     Return a text object at the specified location with a given height
     """
     sm = SpriteMaterial(map=TextTexture(string=text, color='white', size=100, squareTexture=False))
-    return Sprite(material=sm, position = position, scaleToTexture=True, scale=[1,height,1])
+    return Sprite(material=sm, position = position, scaleToTexture=True, scale=[1, height, 1])
 
 def height_texture(z, colormap = 'YlGnBu_r'):
     """Create a texture corresponding to the heights in z and the given colormap."""
@@ -756,12 +867,12 @@ def height_texture(z, colormap = 'YlGnBu_r'):
     import warnings
     with warnings.catch_warnings():
         # ignore the precision warning that comes from converting floats to uint8 types
-        warnings.filterwarnings("ignore",
-                                message="Possible precision loss when converting from",
+        warnings.filterwarnings('ignore',
+                                message='Possible precision loss when converting from',
                                 category=UserWarning,
-                                module="skimage.util.dtype")
-        rgba_im = img_as_ubyte(colormap(im)) # convert the values to rgba image using the colormap
+                                module='skimage.util.dtype')
+        rgba_im = img_as_ubyte(colormap(im))  # convert the values to rgba image using the colormap
 
-    rgba_list = list(rgba_im.flat) # make a flat list
+    rgba_list = list(rgba_im.flat)  # make a flat list
 
     return DataTexture(data=rgba_list, format='RGBAFormat', width=z.shape[1], height=z.shape[0])

--- a/setup.py
+++ b/setup.py
@@ -2,26 +2,31 @@
 
 from distutils.core import setup
 
-setup(name = 'pythreejs',
-      version = '0.1.19',
-      description='Interactive 3d graphics for the Jupyter notebook, using Three.js from IPython widgets.',
-      long_description='A Python/ThreeJS bridge utilizing the IPython widget infrastructure.',
+setup(name='pythreejs',
+      version='0.2.0',
+      description='Interactive 3d graphics for the Jupyter notebook, using Three.js from Jupyter interactive widgets.',
+      long_description='A Python/ThreeJS bridge utilizing the Jupyter widget infrastructure.',
       author='PyThreejs Development Team',
       author_email='jason@jasongrout.org',
       license='BSD',
-      url='https://github.com/jasongrout/pythreejs',
-      requires = ['ipython'],
+      url='https://github.com/jovyan/pythreejs',
+      requires=[
+          'ipywidgets (>4.1.1)'
+          ],
       packages=['pythreejs'],
-      package_data={'pythreejs': [
-      'nbextension/pythreejs.js', 
-      'nbextension/three.js/*.md',
-      'nbextension/three.js/LICENSE',
-      'nbextension/three.js/build/three.js',
-      'nbextension/three.js/examples/js/*.js',
-      'nbextension/three.js/examples/js/controls/*.js',
-      'nbextension/three.js/examples/js/renderers/*.js'
-      ]},
+      package_data={
+          'pythreejs': [
+              'nbextension/pythreejs.js',
+              'nbextension/three.js/*.md',
+              'nbextension/three.js/LICENSE',
+              'nbextension/three.js/build/three.js',
+              'nbextension/three.js/examples/js/*.js',
+              'nbextension/three.js/examples/js/controls/*.js',
+              'nbextension/three.js/examples/js/renderers/*.js'
+          ]
+      },
       keywords=['ipython', 'jupyter', 'widgets', 'webgl', 'graphics', '3d'],
-      classifiers=['Development Status :: 4 - Beta',
-                   'Programming Language :: Python']
-      )
+      classifiers=[
+          'Development Status :: 4 - Beta',
+          'Programming Language :: Python'
+      ])


### PR DESCRIPTION
This PR contains the required changes to make pythreejs compatible with the current (backward incompatible) development version of ipywidgets.

- Add a custom js side model for each pythreejs widget, providing default values on the js side for each widget attribute.
- Remove the Color trait type defined in pythreejs, and now use the one defined in ipywidgets.
- Use the new traitlets API.