### PR TITLE
create _package.py for storing package name info

### DIFF
--- a/pythreejs/__init__.py
+++ b/pythreejs/__init__.py
@@ -1,4 +1,5 @@
 from ._version import version_info, __version__
+from ._package import npm_pkg_name, py_pkg_name
 
 from .pythreejs import (
     Texture,
@@ -139,6 +140,6 @@ def _jupyter_nbextension_paths():
     return [{
         'section': 'notebook',
         'src': 'static',
-        'dest': 'jupyter-threejs',
-        'require': 'jupyter-threejs/extension'
+        'dest': npm_pkg_name,
+        'require': npm_pkg_name + '/extension'
     }]

--- a/pythreejs/_package.py
+++ b/pythreejs/_package.py
@@ -1,0 +1,3 @@
+npm_pkg_name = 'jupyter-threejs'
+py_pkg_name = 'pythreejs'
+

--- a/pythreejs/pythreejs.py
+++ b/pythreejs/pythreejs.py
@@ -15,7 +15,10 @@ Another resource to understanding three.js decisions is the Udacity course on
 from ipywidgets import Widget, DOMWidget, widget_serialization, Color
 from traitlets import (Unicode, Int, CInt, Instance, Enum, List, Dict, Float,
                        CFloat, Bool)
+from ._package import npm_pkg_name
 from math import pi, sqrt
+
+from core import *
 
 def vector3(trait_type=CFloat, default=None, **kwargs):
     if default is None:
@@ -29,8 +32,8 @@ def vector2(trait_type=CFloat, default=None, **kwargs):
 
 
 class Texture(Widget):
-    _view_module = Unicode('jupyter-threejs').tag(sync=True)
-    _model_module = Unicode('jupyter-threejs').tag(sync=True)
+    _view_module = Unicode(npm_pkg_name).tag(sync=True)
+    _model_module = Unicode(npm_pkg_name).tag(sync=True)
     _view_name = Unicode('TextureView').tag(sync=True)
     _model_name = Unicode('TextureModel').tag(sync=True)
 
@@ -92,8 +95,8 @@ class Object3d(Widget):
     """
     If matrix is not None, it overrides the position, rotation, scale, and up variables.
     """
-    _view_module = Unicode('jupyter-threejs').tag(sync=True)
-    _model_module = Unicode('jupyter-threejs').tag(sync=True)
+    _view_module = Unicode(npm_pkg_name).tag(sync=True)
+    _model_module = Unicode(npm_pkg_name).tag(sync=True)
     _view_name = Unicode('Object3dView').tag(sync=True)
     _model_name = Unicode('Object3dModel').tag(sync=True)
 
@@ -205,8 +208,8 @@ class ScaledObject(Object3d):
 
 
 class Controls(Widget):
-    _view_module = Unicode('jupyter-threejs').tag(sync=True)
-    _model_module = Unicode('jupyter-threejs').tag(sync=True)
+    _view_module = Unicode(npm_pkg_name).tag(sync=True)
+    _model_module = Unicode(npm_pkg_name).tag(sync=True)
     _view_name = Unicode('ControlsView').tag(sync=True)
     _model_name = Unicode('ControlsModel').tag(sync=True)
 
@@ -257,8 +260,8 @@ class Picker(Controls):
 
 
 class Geometry(Widget):
-    _view_module = Unicode('jupyter-threejs').tag(sync=True)
-    _model_module = Unicode('jupyter-threejs').tag(sync=True)
+    _view_module = Unicode(npm_pkg_name).tag(sync=True)
+    _model_module = Unicode(npm_pkg_name).tag(sync=True)
     _view_name = Unicode('GeometryView').tag(sync=True)
     _model_name = Unicode('GeometryModel').tag(sync=True)
 
@@ -452,8 +455,8 @@ class ParametricGeometry(Geometry):
 
 
 class Material(Widget):
-    _view_module = Unicode('jupyter-threejs').tag(sync=True)
-    _model_module = Unicode('jupyter-threejs').tag(sync=True)
+    _view_module = Unicode(npm_pkg_name).tag(sync=True)
+    _model_module = Unicode(npm_pkg_name).tag(sync=True)
     _view_name = Unicode('MaterialView').tag(sync=True)
     _model_name = Unicode('MaterialModel').tag(sync=True)
 
@@ -742,8 +745,8 @@ class Scene(Object3d):
 
 
 class Effect(Widget):
-    _view_module = Unicode('jupyter-threejs').tag(sync=True)
-    _model_module = Unicode('jupyter-threejs').tag(sync=True)
+    _view_module = Unicode(npm_pkg_name).tag(sync=True)
+    _model_module = Unicode(npm_pkg_name).tag(sync=True)
 
 
 class AnaglyphEffect(Effect):
@@ -752,8 +755,8 @@ class AnaglyphEffect(Effect):
 
 
 class Renderer(DOMWidget):
-    _view_module = Unicode('jupyter-threejs').tag(sync=True)
-    _model_module = Unicode('jupyter-threejs').tag(sync=True)
+    _view_module = Unicode(npm_pkg_name).tag(sync=True)
+    _model_module = Unicode(npm_pkg_name).tag(sync=True)
     _view_name = Unicode('RendererView').tag(sync=True)
     _model_name = Unicode('RendererModel').tag(sync=True)
 

--- a/pythreejs/pythreejs.py
+++ b/pythreejs/pythreejs.py
@@ -18,8 +18,6 @@ from traitlets import (Unicode, Int, CInt, Instance, Enum, List, Dict, Float,
 from ._package import npm_pkg_name
 from math import pi, sqrt
 
-from core import *
-
 def vector3(trait_type=CFloat, default=None, **kwargs):
     if default is None:
         default = [0, 0, 0]


### PR DESCRIPTION
This is the start of some clean-up/organization I'd like to do within the codebase.  I think the project could benefit greatly by mirroring the hierarchy of the three.js code base.  

Anyways, this is just a tiny little PR to gauge whether you're welcoming to contribution or not.  My plan is to split the python libraries out into separate files corresponding to the different sections of the three.js docs:

- cameras
- extras
- materials
- objects
- renderers
- scenes
- textures

etc. ...

The result would be that `__init__.py` imports vars from a number of files as opposed to a single python file. 

I'm curious what you think, and if you're open to me working on some clean-up/organization.  Thanks!