### PR TITLE
Add some basic CI checks of examples and links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,15 @@ pythreejs/static/
 # OS X
 .DS_Store
 
-
+# Autogen files
 *_autogen.py
 *.autogen.js
 js/src/**/index.js
 pythreejs/**/__init__.py
+
+# Test and coverage
+.coverage
+.cache
+htmlcov/
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ install:
   - pip install --upgrade -e ".[test, examples]"
 script:
   - py.test -l --nbval-lax --current-env examples
+  - python -m pytest_check_links

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+python:
+  - 3.5
+  - 3.4
+  - 2.7
+sudo: false
+cache:
+  pip: true
+  directories:
+    - ~/.npm  # NPM cache
+before_install:
+  - pip install -U pip setuptools
+  - nvm install 6
+install:
+  - pip install --upgrade -e ".[test, examples]"
+script:
+  - py.test -l --nbval-lax --current-env examples

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Python / ThreeJS bridge utilizing the Jupyter widget infrastructure.
 
-![Screencast](/screencast.gif)
+![Screencast](screencast.gif)
 
 ## Getting Started
 

--- a/examples/Animation.ipynb
+++ b/examples/Animation.ipynb
@@ -288,7 +288,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-skip"
+    ]
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -315,7 +319,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-skip"
+    ]
+   },
    "outputs": [],
    "source": [
     "pill_track = NumberKeyframeTrack(name='.morphTargetInfluences[0]', times=[0, 1.5, 3], values=[0, 2.5, 0])\n",
@@ -326,7 +334,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-skip"
+    ]
+   },
    "outputs": [],
    "source": [
     "camera3 = PerspectiveCamera( position=[5, 3, 5], aspect=view_width/view_height)\n",

--- a/js/scripts/generate-wrappers.js
+++ b/js/scripts/generate-wrappers.js
@@ -948,16 +948,20 @@ function createPythonFiles() {
     return mapPromiseFnOverThreeModules(function(relativePath) {
             return createPythonWrapper(relativePath).then(function() {
                 // ensures each dir has empty __init__.py file for proper importing of sub dirs
-                createPythonModuleInitFile(relativePath);
+                return createPythonModuleInitFile(relativePath);
             });
         })
         .then(function() {
             return mapPromiseFnOverFileList(CUSTOM_CLASSES, function(relativePath) {
                 return createPythonWrapper(relativePath).then(function() {
                     // ensures each dir has empty __init__.py file for proper importing of sub dirs
-                    createPythonModuleInitFile(relativePath);
+                    return createPythonModuleInitFile(relativePath);
                 });
             });
+        })
+        .then(function() {
+            // Manually ensure base init file is created
+            return createPythonModuleInitFile('_base/__init__');
         })
         .then(function() {
             // top level __init__.py file imports *all* pythreejs modules into namespace

--- a/js/scripts/templates/py_wrapper.mustache
+++ b/js/scripts/templates/py_wrapper.mustache
@@ -1,5 +1,4 @@
-import inspect
-
+import six
 from ipywidgets import Widget, DOMWidget, widget_serialization, Color, register
 from traitlets import (
     Unicode, Int, CInt, Instance, ForwardDeclaredInstance, This, Enum,
@@ -41,6 +40,7 @@ class {{ className }}({{ superClass.className }}):
     {{/each}}
 
 
-# Include explicit signature since the metaclass screws it up
-{{ className }}.__signature__ = inspect.signature({{ className }}.__init__)
-
+if six.PY3:
+    import inspect
+    # Include explicit signature since the metaclass screws it up
+    {{ className }}.__signature__ = inspect.signature({{ className }}.__init__)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = .git node_modules htmlcov .ipynb_checkpoints

--- a/pythreejs/core/Renderer.py
+++ b/pythreejs/core/Renderer.py
@@ -1,7 +1,7 @@
 """
 """
-from inspect import Signature, Parameter
 
+import six
 from ipywidgets import widget_serialization, Color
 from traitlets import (
     Unicode, CInt, Instance, Float, Tuple, Undefined, link)
@@ -58,15 +58,18 @@ class Renderer(RenderableWidget):
         }
         self.send(content)
 
-# Include explicit signature since the metaclass screws it up
-parameters = [
-    Parameter('scene', Parameter.POSITIONAL_OR_KEYWORD),
-    Parameter('camera', Parameter.POSITIONAL_OR_KEYWORD),
-    Parameter('controls', Parameter.POSITIONAL_OR_KEYWORD, default=None),
-]
-for name in ('width', 'height', 'background', 'background_opacity'):
-    parameters.append(Parameter(
-        name, Parameter.KEYWORD_ONLY, default=getattr(Renderer, name).default_value))
-parameters.append(Parameter('kwargs', Parameter.VAR_KEYWORD))
-Renderer.__signature__ = Signature(parameters=tuple(parameters))
-del parameters
+
+if six.PY3:
+    from inspect import Signature, Parameter
+    # Include explicit signature since the metaclass screws it up
+    parameters = [
+        Parameter('scene', Parameter.POSITIONAL_OR_KEYWORD),
+        Parameter('camera', Parameter.POSITIONAL_OR_KEYWORD),
+        Parameter('controls', Parameter.POSITIONAL_OR_KEYWORD, default=None),
+    ]
+    for name in ('width', 'height', 'background', 'background_opacity'):
+        parameters.append(Parameter(
+            name, Parameter.KEYWORD_ONLY, default=getattr(Renderer, name).default_value))
+    parameters.append(Parameter('kwargs', Parameter.VAR_KEYWORD))
+    Renderer.__signature__ = Signature(parameters=tuple(parameters))
+    del parameters

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,16 @@ setup_args = {
         'ipywidgets>=7,<8',
         'ipydatawidgets>=1.1.1'
     ],
+    'extras_require': {
+        'test': [
+            'nbval',
+        ],
+        'examples': [
+            'scipy',
+            'matplotlib',
+            'scikit-image'
+        ],
+    },
     'packages': find_packages(),
     'zip_safe': False,
     'cmdclass': cmdclass,

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup_args = {
     'extras_require': {
         'test': [
             'nbval',
+            'pytest-check-links',
         ],
         'examples': [
             'scipy',


### PR DESCRIPTION
Adds some basic travis CI:
 - Uses [nbval](https://github.com/computationalmodelling/nbval) to check that the example notebooks run without errors (they currently do not). It is also set up to generate a coverage report based on the examples, but this can be removed if not wanted.
 - Uses [pytest-check-links](https://github.com/minrk/pytest-check-links) to check links in example notebooks and HTML/markdown files. One nitpick was found and fixed.

Based on #83 for improved setup.