### PR TITLE
Make setup.py run on Windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ class NPM(Command):
 
     def has_npm(self):
         try:
-            check_call(['npm', '--version'])
+            check_call(['npm', '--version'], shell=True)
             return True
         except:
             return False
@@ -100,7 +100,7 @@ class NPM(Command):
 
         if self.should_run_npm_install():
             log.info("Installing build dependencies with npm.  This may take a while...")
-            check_call(['npm', 'install'], cwd=node_root, stdout=sys.stdout, stderr=sys.stderr)
+            check_call(['npm', 'install'], cwd=node_root, stdout=sys.stdout, stderr=sys.stderr, shell=True)
             os.utime(self.node_modules, None)
 
         for t in self.targets:


### PR DESCRIPTION
When installing with Windows, `subprocess.check_call` fails to find npm without `shell=True` getting passed in.  This happens because `subprocess.Popen` searches only for files that end in .exe, and when npm is installed it is a `.cmd` file.  Setting `shell=True` lets the shell interpret the command, so it finds the `npm.cmd` file.