### PR TITLE
Bugfix: make BlackboxModel create an Object3D instead of Blackbox

### DIFF
--- a/js/src/objects/Blackbox.js
+++ b/js/src/objects/Blackbox.js
@@ -30,6 +30,13 @@ var BlackboxModel = BlackboxAutogen.extend({
     },
 
 
+    constructThreeObject: function() {
+
+        var result = new THREE.Object3D();
+        return Promise.resolve(result);
+
+    },
+
     createPropertiesArrays: function() {
 
         BlackboxAutogen.prototype.createPropertiesArrays.call(this);


### PR DESCRIPTION
The autogenerated BlackBoxModel creates a `new THREE.Blackbox()` which doesn't exist.

This override creates an Object3D instead.

Note that I still have problems getting my blackbox subclass to actually render, getting `this.parent === undefined` at the last line here in `Object3D`:
```
		updateMatrixWorld: function ( force ) {

			if ( this.matrixAutoUpdate ) this.updateMatrix();

			if ( this.matrixWorldNeedsUpdate || force ) {

				if ( this.parent === null ) {

					this.matrixWorld.copy( this.matrix );

				} else {

					this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
```

I haven't been able to find any place where this.parent is actually set to undefined, it's initialized to null everywhere I've seen.