### PR TITLE
Enable shadows, antialias and other renderer config

### DIFF
--- a/examples/Shadows.ipynb
+++ b/examples/Shadows.ipynb
@@ -1,6 +1,24 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Shadows with pythreejs\n",
+    "\n",
+    "This example is meant to demonstrate how to set up shadows with pythreejs. It is mainly based on the example code you can find in the three.js documentation, but is adapted to highlight some of the nuances of using it from pythreejs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "First, we set up an example scene for exploring shadow behavior."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -19,6 +37,13 @@
    "source": [
     "view_width = 800\n",
     "view_height = 600"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create some example geometry in nice coder colors:"
    ]
   },
   {
@@ -60,6 +85,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create camera and lighting:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -67,7 +99,6 @@
    "source": [
     "camera = PerspectiveCamera( position=[10, 6, 10], aspect=view_width/view_height)\n",
     "key_light = SpotLight(position=[0, 10, 10], angle = 0.3, penumbra = 0.1)\n",
-    "key_light.target = cube\n",
     "ambient_light = AmbientLight()"
    ]
   },
@@ -86,10 +117,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "renderer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configuring shadows\n",
+    "\n",
+    "Now we can start playing around with the shadows in such a way that the results of the different options are immediately shown in the rendered scene."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, set the spot light to track the cube position:"
    ]
   },
   {
@@ -98,9 +147,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Turn on shadows in the renderer\n",
+    "key_light.target = cube"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Turn on shadows in the renderer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "renderer.shadowMap.enabled = True\n",
     "renderer.shadowMap.type = 'PCFSoftShadowMap'  # default PCFShadowMap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Even with shadow maps enabled, there are still no shadows. This is because three.js only includes those lights and objects that has been explicitly marked for shadows in its calculations. Let's turn on some of these:"
    ]
   },
   {
@@ -111,10 +182,18 @@
    "source": [
     "# Enable shadows for the light\n",
     "key_light.castShadow = True\n",
-    "# Enable objects for casting/receiving shadows:\n",
+    "\n",
+    "# Enable casting/receiving shadows for some objects:\n",
     "sphere.castShadow = True\n",
     "cube.castShadow = True\n",
     "plane.receiveShadow = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's move the cube closer to the sphere:"
    ]
   },
   {
@@ -124,6 +203,13 @@
    "outputs": [],
    "source": [
     "cube.position = (0, 1, 2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the light changed to track the position of the cube. It is also clear that the shadow from the cube is not being taken into account on the sphere. As before, we can turn this on with `receiveShadow` on the sphere, but we also need to mark the sphere material for an update. This is needed for any shadow changes *after the first frame with shadows* is rendered."
    ]
   },
   {
@@ -138,12 +224,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "key_light.shadow.mapSize = (2048, 2048)"
+    "Finally, let's zoom in on the details of the shadows:"
    ]
   },
   {
@@ -152,7 +236,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "repr(key_light.shadow.camera)"
+    "camera.position = [2.92, 1.75, 2.92]\n",
+    "camera.quaternion = [-0.18, 0.38, 0.076, 0.90]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, we can see that there is some pixelation of the shadows (although it is smoothed by using `PCFSoftShadowMap`). This can be fixed by increasing the resolution of the shadow map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "key_light.shadow.mapSize = (2048, 2048)"
    ]
   },
   {

--- a/examples/Shadows.ipynb
+++ b/examples/Shadows.ipynb
@@ -1,0 +1,187 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pythreejs import *\n",
+    "import ipywidgets\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view_width = 800\n",
+    "view_height = 600"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sphere = Mesh(\n",
+    "    SphereBufferGeometry(1, 32, 16),\n",
+    "    MeshStandardMaterial(color='red')\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cube = Mesh(\n",
+    "    BoxBufferGeometry(1, 1, 1),\n",
+    "    MeshPhysicalMaterial(color='green'),\n",
+    "    position=[2, 0, 4]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plane = Mesh(\n",
+    "    PlaneBufferGeometry(10, 10),\n",
+    "    MeshPhysicalMaterial(color='gray'),\n",
+    "    position=[0, -2, 0],)\n",
+    "plane.rotation = (-3.14/2, 0, 0, 'XYZ')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "camera = PerspectiveCamera( position=[10, 6, 10], aspect=view_width/view_height)\n",
+    "key_light = SpotLight(position=[0, 10, 10], angle = 0.3, penumbra = 0.1)\n",
+    "key_light.target = cube\n",
+    "ambient_light = AmbientLight()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scene = Scene(children=[sphere, cube, plane, camera, key_light, ambient_light])\n",
+    "controller = OrbitControls(controlling=camera)\n",
+    "renderer = Renderer(camera=camera, scene=scene, controls=[controller],\n",
+    "                    width=view_width, height=view_height, antialias=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "renderer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Turn on shadows in the renderer\n",
+    "renderer.shadowMap.enabled = True\n",
+    "renderer.shadowMap.type = 'PCFSoftShadowMap'  # default PCFShadowMap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Enable shadows for the light\n",
+    "key_light.castShadow = True\n",
+    "# Enable objects for casting/receiving shadows:\n",
+    "sphere.castShadow = True\n",
+    "cube.castShadow = True\n",
+    "plane.receiveShadow = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cube.position = (0, 1, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Also enable sphere to receive shadow:\n",
+    "sphere.receiveShadow = True\n",
+    "sphere.material.needsUpdate = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "key_light.shadow.mapSize = (2048, 2048)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repr(key_light.shadow.camera)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/js/scripts/generate-wrappers.js
+++ b/js/scripts/generate-wrappers.js
@@ -59,7 +59,18 @@ var IGNORE_FILES = [
     '**/materials/MeshDistanceMaterial.js', // TODO: Undocumented as of yet
     '**/renderers/WebGLRenderer.js',        // For now, the internals of the webgl
     '**/renderers/WebGL2Renderer.js',       //   render is not exposed.
-    '**/renderers/webgl/**',
+    //'**/renderers/webgl/**',
+    '**/renderers/webgl/WebGLAttributes.js',
+    '**/renderers/webgl/WebGLBackground.js',
+    '**/renderers/webgl/WebGLClipping.js',
+    '**/renderers/webgl/WebGLFlareRenderer.js',
+    '**/renderers/webgl/WebGLMorphtargets.js',
+    '**/renderers/webgl/WebGLRenderLists.js',
+    '**/renderers/webgl/WebGLSpriteRenderer.js',
+    '**/renderers/webgl/WebGLTextures.js',
+    '**/renderers/webgl/WebGLUniforms.js',
+    '**/renderers/webgl/WebGLUtils.js',
+    '**/renderers/webvr/**',
     '**/renderers/shaders/**',
     '**/extras/core/Interpolations.js',     // Only functions, nothing to export
     '**/extras/core/PathPrototype.js',      // Sub-part of one object, ignore

--- a/js/scripts/generate-wrappers.js
+++ b/js/scripts/generate-wrappers.js
@@ -817,10 +817,6 @@ _.extend(PythonWrapper.prototype, {
 
         var refTokens = this.modulePath.split(pathSep);
 
-        // capitalize elements in url
-        refTokens = refTokens.map(function(token) {
-            return token.charAt(0).toUpperCase() + token.slice(1);
-        });
         // strip extension off filename
         refTokens[refTokens.length - 1] = path.basename(refTokens[refTokens.length - 1], '.js');
 

--- a/js/scripts/prop-types.js
+++ b/js/scripts/prop-types.js
@@ -101,8 +101,28 @@ function InitializedThreeType(typeName, options={}) {
     ThreeType.call(this, typeName, options);
 }
 _.extend(InitializedThreeType.prototype, ThreeType.prototype, {
-    getPropertyConverterFn: function() {
-        return 'convertInitializedThreeType';
+    getJSPropertyValue: function() {
+        return '"uninitialized"';
+    },
+    getPythonDefaultValue: function() {
+        return 'UninitializedSentinel';
+    },
+    getTraitlet: function() {
+        var typeName = this.typeName;
+        var nullableStr = this.nullable ? 'True' : 'False';
+        var inst = `Instance(${typeName}`;
+        if (this.args !== undefined) {
+            inst += `, args=${this.args}`;
+        }
+        if (this.kwargs !== undefined) {
+            inst += `, kw=${this.kwargs}`;
+        }
+        inst += `)`;
+        var uninit = 'Instance(Uninitialized)';
+        var ret = `Union([\n        ${uninit},\n        ${inst}\n        ]`
+        ret += `, default_value=${this.getPythonDefaultValue()}, allow_none=${nullableStr})`;
+        ret += `.tag(sync=True, **unitialized_serialization)`;
+        return ret;
     },
 });
 

--- a/js/scripts/templates/py_wrapper.mustache
+++ b/js/scripts/templates/py_wrapper.mustache
@@ -6,6 +6,7 @@ from traitlets import (
     Tuple, List, Dict, Float, CFloat, Bool, Union, Any,
     )
 
+from {{ py_base_relative_path }}_base.Three import ThreeWidget
 from {{ py_base_relative_path }}enums import *
 from {{ py_base_relative_path }}traits import *
 

--- a/js/scripts/three-class-config.js
+++ b/js/scripts/three-class-config.js
@@ -470,16 +470,19 @@ module.exports = {
         relativePath: './lights/DirectionalLight',
         superClass: 'Light',
         properties: {
-            target:      new Types.InitializedThreeType('Object3D', {args: '()', nullable: false}),
-            // TODO: shadows
-            // shadow:      new Types.ThreeType('LightShadow'),
-            castsShadow: new Types.Bool(false),
+            target:      new Types.InitializedThreeType('Object3D', null, {args: '()', nullable: false}),
+            shadow:      new Types.InitializedThreeType('DirectionalLightShadow', 'LightShadow', {args: '()', nullable: false}),
         },
         constructorArgs: [ 'color', 'intensity' ],
-        propsDefinedByThree: [ 'target' ]
+        propsDefinedByThree: [ 'target', 'shadow' ]
     },
     DirectionalLightShadow: {
         relativePath: './lights/DirectionalLightShadow',
+        superClass: 'LightShadow',
+        properties: {
+            // TODO: Fix this
+            camera:     new Types.InitializedThreeType('OrthographicCamera', 'Camera', {args: '()'}),
+        },
     },
     HemisphereLight: {
         relativePath: './lights/HemisphereLight',
@@ -500,6 +503,15 @@ module.exports = {
     },
     LightShadow: {
         relativePath: './lights/LightShadow',
+        properties: {
+            // TODO: Fix this
+            camera:     new Types.ThreeType('Camera', {args: '()'}),
+            bias:       new Types.Float(0),
+            mapSize:    new Types.Vector2(512, 512),
+            radius:     new Types.Float(1)
+        },
+        constructorArgs: [ 'camera' ],
+        propsDefinedByThree: [ 'camera' ],
     },
     PointLight: {
         relativePath: './lights/PointLight',
@@ -508,10 +520,10 @@ module.exports = {
             power:    new Types.Float(4.0 * Math.PI),
             distance: new Types.Float(0.0),
             decay:    new Types.Float(1.0),
-            // TODO: shadows
-            // shadow:   new Types.ThreeType('LightShadow'),
+            shadow:   new Types.InitializedThreeType('LightShadow', null, {args: '()'}),
         },
         constructorArgs: [ 'color', 'intensity', 'distance', 'decay' ],
+        propsDefinedByThree: [ 'shadow' ],
     },
     RectAreaLight: {
         relativePath: './lights/RectAreaLight',
@@ -521,19 +533,23 @@ module.exports = {
         relativePath: './lights/SpotLight',
         superClass: 'Light',
         properties: {
-            target:   new Types.InitializedThreeType('Object3D', {args: '()', nullable: false}),
+            target:   new Types.InitializedThreeType('Object3D', null, {args: '()', nullable: false}),
             distance: new Types.Float(0.0),
             angle:    new Types.Float(Math.PI / 3.0),
             penumbra: new Types.Float(0.0),
             decay:    new Types.Float(1.0),
-            // TODO: shadows
-            // shadow:   new Types.ThreeType('LightShadow'),
+            shadow:   new Types.InitializedThreeType('SpotLightShadow', 'LightShadow', {args: '()'}),
         },
         constructorArgs: [ 'color', 'intensity', 'distance', 'angle', 'penumbra', 'decay' ],
-        propsDefinedByThree: [ 'target' ]
+        propsDefinedByThree: [ 'target', 'shadow' ]
     },
     SpotLightShadow: {
         relativePath: './lights/SpotLightShadow',
+        superClass: 'LightShadow',
+        properties: {
+            // TODO: Fix this
+            camera:     new Types.InitializedThreeType('PerspectiveCamera', 'Camera', {args: '()'}),
+        },
     },
     AnimationLoader: {
         relativePath: './loaders/AnimationLoader',
@@ -1160,6 +1176,21 @@ module.exports = {
     },
     WebGLRenderer: {
         relativePath: './renderers/WebGLRenderer',
+        properties: {
+            clippingPlanes:             new Types.ThreeTypeArray('Plane'),
+            gammaFactor:                new Types.Float(2),
+            gammaInput:                 new Types.Bool(false),
+            gammaOutput:                new Types.Bool(false),
+            localClippingEnabled:       new Types.Bool(false),
+            physicallyCorrectLights:    new Types.Bool(false),
+            // Note: shadow map has custom handling in `Renderable` base class
+            shadowMap:                  new Types.ThreeType('WebGLShadowMap'),
+            sortObjects:                new Types.Bool(false),
+            toneMapping:                new Types.Enum('ToneMappings', 'LinearToneMapping'),
+            toneMappingExposure:        new Types.Float(1.0),
+            toneMappingWhitepoint:      new Types.Float(1.0),
+        },
+        propsDefinedByThree: ['shadowMap']
     },
     Fog: {
         relativePath: './scenes/Fog',

--- a/js/scripts/three-class-config.js
+++ b/js/scripts/three-class-config.js
@@ -656,7 +656,7 @@ module.exports = {
             visible:                new Types.Bool(true),
             opacity:                new Types.Float(1.0),
         },
-        propsDefinedByThree: [ 'type' ]
+        propsDefinedByThree: [ 'type', 'needsUpdate' ]
     },
     MeshBasicMaterial: {
         relativePath: './materials/MeshBasicMaterial',

--- a/js/scripts/three-class-config.js
+++ b/js/scripts/three-class-config.js
@@ -280,7 +280,7 @@ module.exports = {
             version:     new Types.Int(-1),
         },
         constructorArgs: [ 'array', 'normalized' ],
-        propsDefinedByThree: [ 'version' ]
+        propsDefinedByThree: [ 'version', 'needsUpdate' ]
     },
     BufferGeometry: {
         relativePath: './core/BufferGeometry',
@@ -389,7 +389,7 @@ module.exports = {
             version:        new Types.Int(0),
             needsUpdate:    new Types.Bool(false),
         },
-        propsDefinedByThree: ['version'],
+        propsDefinedByThree: ['version', 'needsUpdate'],
         constructorArgs: ['array', 'stride'],
     },
     InterleavedBufferAttribute: {
@@ -431,7 +431,7 @@ module.exports = {
             frustumCulled:          new Types.Bool(true),
             renderOrder:            new Types.Int(0),
         },
-        propsDefinedByThree: [ 'type', 'rotation', 'quaternion' ]
+        propsDefinedByThree: [ 'type', 'rotation', 'quaternion', 'matrixWorldNeedsUpdate' ]
     },
     Blackbox: {
         superClass: 'Object3D',
@@ -656,7 +656,7 @@ module.exports = {
             visible:                new Types.Bool(true),
             opacity:                new Types.Float(1.0),
         },
-        propsDefinedByThree: [ 'type', 'needsUpdate' ]
+        propsDefinedByThree: [ 'type' ]
     },
     MeshBasicMaterial: {
         relativePath: './materials/MeshBasicMaterial',

--- a/js/scripts/three-class-config.js
+++ b/js/scripts/three-class-config.js
@@ -470,8 +470,8 @@ module.exports = {
         relativePath: './lights/DirectionalLight',
         superClass: 'Light',
         properties: {
-            target:      new Types.InitializedThreeType('Object3D', null, {args: '()', nullable: false}),
-            shadow:      new Types.InitializedThreeType('DirectionalLightShadow', 'LightShadow', {args: '()', nullable: false}),
+            target:      new Types.InitializedThreeType('Object3D', {nullable: false}),
+            shadow:      new Types.InitializedThreeType('LightShadow', {nullable: false}),
         },
         constructorArgs: [ 'color', 'intensity' ],
         propsDefinedByThree: [ 'target', 'shadow' ]
@@ -479,10 +479,6 @@ module.exports = {
     DirectionalLightShadow: {
         relativePath: './lights/DirectionalLightShadow',
         superClass: 'LightShadow',
-        properties: {
-            // TODO: Fix this
-            camera:     new Types.InitializedThreeType('OrthographicCamera', 'Camera', {args: '()'}),
-        },
     },
     HemisphereLight: {
         relativePath: './lights/HemisphereLight',
@@ -504,8 +500,7 @@ module.exports = {
     LightShadow: {
         relativePath: './lights/LightShadow',
         properties: {
-            // TODO: Fix this
-            camera:     new Types.ThreeType('Camera', {args: '()'}),
+            camera:     new Types.InitializedThreeType('Camera', {nullable: false}),
             bias:       new Types.Float(0),
             mapSize:    new Types.Vector2(512, 512),
             radius:     new Types.Float(1)
@@ -520,7 +515,7 @@ module.exports = {
             power:    new Types.Float(4.0 * Math.PI),
             distance: new Types.Float(0.0),
             decay:    new Types.Float(1.0),
-            shadow:   new Types.InitializedThreeType('LightShadow', null, {args: '()'}),
+            shadow:   new Types.InitializedThreeType('LightShadow', {nullable: false}),
         },
         constructorArgs: [ 'color', 'intensity', 'distance', 'decay' ],
         propsDefinedByThree: [ 'shadow' ],
@@ -533,12 +528,12 @@ module.exports = {
         relativePath: './lights/SpotLight',
         superClass: 'Light',
         properties: {
-            target:   new Types.InitializedThreeType('Object3D', null, {args: '()', nullable: false}),
+            target:   new Types.InitializedThreeType('Object3D', {nullable: false}),
             distance: new Types.Float(0.0),
             angle:    new Types.Float(Math.PI / 3.0),
             penumbra: new Types.Float(0.0),
             decay:    new Types.Float(1.0),
-            shadow:   new Types.InitializedThreeType('SpotLightShadow', 'LightShadow', {args: '()'}),
+            shadow:   new Types.InitializedThreeType('LightShadow', {nullable: false}),
         },
         constructorArgs: [ 'color', 'intensity', 'distance', 'angle', 'penumbra', 'decay' ],
         propsDefinedByThree: [ 'target', 'shadow' ]
@@ -546,10 +541,6 @@ module.exports = {
     SpotLightShadow: {
         relativePath: './lights/SpotLightShadow',
         superClass: 'LightShadow',
-        properties: {
-            // TODO: Fix this
-            camera:     new Types.InitializedThreeType('PerspectiveCamera', 'Camera', {args: '()'}),
-        },
     },
     AnimationLoader: {
         relativePath: './loaders/AnimationLoader',

--- a/js/src/_base/Renderable.js
+++ b/js/src/_base/Renderable.js
@@ -59,6 +59,7 @@ var RenderableModel = widgets.DOMWidgetModel.extend({
         ThreeModel.prototype.createPropertiesArrays.call(this);
         this.three_nested_properties.push('clippingPlanes');
         this.three_properties.push('shadowMap');
+        this.props_created_by_three['shadowMap'] = true;
 
         this.enum_property_types['toneMapping'] = 'ToneMappings';
 

--- a/js/src/_base/Renderable.js
+++ b/js/src/_base/Renderable.js
@@ -8,6 +8,8 @@ var THREE = require('three');
 var pkgName = require('../../package.json').name;
 var RendererPool = require('./RendererPool');
 
+var ThreeModel = require('./Three').ThreeModel;
+
 var RenderableModel = widgets.DOMWidgetModel.extend({
 
     defaults: function() {
@@ -19,10 +21,79 @@ var RenderableModel = widgets.DOMWidgetModel.extend({
 
             _width: 200,
             _height: 200,
+            _antialias: false,
+
+            autoClear: true,
+            autoClearColor: true,
+            autoClearDepth: true,
+            autoClearStencil: true,
+            clippingPlanes: [],
+            gammaFactor: 2.0,
+            gammaInput: false,
+            gammaOutput: false,
+            localClippingEnabled: false,
+            maxMorphTargets: 8,
+            maxMorphNormals: 4,
+            physicallyCorrectLights: false,
+            shadowMap: null,
+            sortObject: true,
+            toneMapping: 'LinearToneMapping',
+            toneMappingExposure: 1.0,
+            toneMappingWhitePoint: 1.0,
+
+            // Properties that are set by functions
+            clearColor: '#000000',
+            clearOpacity: 1.0,
         });
     },
 
+    initialize: function(attributes, options) {
+        widgets.DOMWidgetModel.prototype.initialize.apply(this, arguments);
+
+        this.createPropertiesArrays();
+        ThreeModel.prototype.setupListeners.call(this);
+    },
+
+    createPropertiesArrays: function() {
+        // This does not inherit ThreeModel, but follow same pattern
+        ThreeModel.prototype.createPropertiesArrays.call(this);
+        this.three_nested_properties.push('clippingPlanes');
+        this.three_properties.push('shadowMap');
+
+        this.enum_property_types['toneMapping'] = 'ToneMappings';
+
+        this.property_converters['autoClear'] = 'convertBool';
+        this.property_converters['autoClearColor'] = 'convertBool';
+        this.property_converters['autoClearDepth'] = 'convertBool';
+        this.property_converters['autoClearStencil'] = 'convertBool';
+        this.property_converters['clippingPlanes'] = 'convertThreeTypeArray';
+        this.property_converters['gammaFactor'] = 'convertFloat';
+        this.property_converters['gammaInput'] = 'convertBool';
+        this.property_converters['gammaOutput'] = 'convertBool';
+        this.property_converters['localClippingEnabled'] = 'convertBool';
+        this.property_converters['physicallyCorrectLights'] = 'convertBool';
+        this.property_converters['sortObjects'] = 'convertBool';
+        this.property_converters['toneMapping'] = 'convertEnum';
+        this.property_converters['toneMappingExposure'] = 'convertFloat';
+        this.property_converters['toneMappingWhitepoint'] = 'convertFloat';
+    },
+
+    onChange: function(model, options) {
+    },
+
+    onChildChanged: function(model, options) {
+        console.log('child changed: ' + model.model_id);
+        // Let listeners (e.g. views) know:
+        this.trigger('childchange', this);
+    },
+
+}, {
+    serializers: _.extend({
+        clippingPlanes: { deserialize: widgets.unpack_models },
+        shadowMap: { deserialize: widgets.unpack_models },
+    }, widgets.DOMWidgetModel.serializers)
 });
+
 
 var RenderableView = widgets.DOMWidgetView.extend({
 
@@ -89,6 +160,80 @@ var RenderableView = widgets.DOMWidgetView.extend({
         }
     },
 
+    updateProperties: function(force) {
+        if (this.isFrozen) {
+            return;
+        }
+        var model = this.model;
+
+        _.each(model.property_converters, function(converterName, propName) {
+            if (!force && !(model._changing && model.hasChanged(propName))) {
+                // Only set changed properties unless forced
+                return;
+            }
+            if (!converterName) {
+                this.renderer[propName] = this.model.get(propName);
+                return;
+            }
+            if (converterName === 'convertThreeTypeArray') {
+                var converterFn = this[converterName].bind(this);
+            } else {
+                converterName = converterName + "ModelToThree";
+                var converterFn = ThreeModel.prototype[converterName];
+            }
+
+            if (!converterFn) {
+                throw new Error('invalid converter name: ' + converterName);
+            }
+            this.renderer[propName] = converterFn(model.get(propName), propName);
+        }, this);
+
+        // Deal with shadow map
+        this._updateShadowMap(force);
+
+        var clearColor = ThreeModel.prototype.convertColorModelToThree(model.get('clearColor'));
+        var clearOpacity = ThreeModel.prototype.convertFloatModelToThree(model.get('clearOpacity'));
+        this.renderer.setClearColor(clearColor, clearOpacity);
+    },
+
+    _updateShadowMap: function(force) {
+        var model = this.model.get('shadowMap');
+        var obj = this.renderer.shadowMap;
+        var changes = false;
+        _.each(model.property_converters, function(converterName, propName) {
+            if (!force && !(model._changing && model.hasChanged(propName))) {
+                // Only set changed properties unless forced
+                return;
+            }
+            if (!converterName) {
+                obj[propName] = this.model.get(propName);
+                changes = true;
+                return;
+            }
+            if (converterName === 'convertThreeTypeArray') {
+                var converterFn = this[converterName].bind(this);
+            } else {
+                converterName = converterName + "ModelToThree";
+                var converterFn = ThreeModel.prototype[converterName];
+            }
+
+            if (!converterFn) {
+                throw new Error('invalid converter name: ' + converterName);
+            }
+            obj[propName] = converterFn(model.get(propName), propName);
+            changes = true;
+        }, this);
+        if (changes) {
+            obj.needsUpdate = true;
+        }
+    },
+
+    convertThreeTypeArray: function(modelArr, propName) {
+        return modelArr.map(function(model) {
+            return ThreeModel.prototype.convertThreeTypeModelToThree(model, propName);
+        }, this);
+    },
+
     renderScene: function(scene, camera) {
         this.log('renderScene');
 
@@ -138,7 +283,12 @@ var RenderableView = widgets.DOMWidgetView.extend({
 
         this.log('ThreeView.acquiring...');
 
-        this.renderer = RendererPool.acquire(this.onRendererReclaimed.bind(this));
+        var config = {
+            antialias: this.model.get('_antialias'),
+        };
+        this.renderer = RendererPool.acquire(
+            config,
+            this.onRendererReclaimed.bind(this));
 
         this.$renderer = $(this.renderer.domElement);
         this.$el.empty().append(this.$renderer);

--- a/js/src/_base/Three.js
+++ b/js/src/_base/Three.js
@@ -69,6 +69,9 @@ var ThreeModel = widgets.WidgetModel.extend({
 
             // We need to push a default state first, as comm open does
             // not support buffers!
+            // Fixed in:
+            // - @jupyterlab/services@0.49.0
+            // - notebook 5.1.0
             this.save_changes();
 
             var obj = options.three_obj;

--- a/js/src/_base/utils.js
+++ b/js/src/_base/utils.js
@@ -213,11 +213,13 @@ function createModel(constructor, widget_manager, obj) {
         delete widget_manager._models[id];
     });
 
-    var data, buffers;
     widget_manager._models[id] = widget_model.initPromise.then(() => {
+        // Create un-opened comm:
+        return widget_manager._create_comm(widget_manager.comm_target_name, id);
+    }).then(comm => {
         var split = widgets.remove_buffers(
             widget_model.serialize(widget_model.get_state(true)));
-        data = {
+        var data = {
             state: _.extend({}, split.state, {
                 _model_name: constructor.model_name,
                 _model_module: constructor.model_module,
@@ -228,12 +230,8 @@ function createModel(constructor, widget_manager, obj) {
             }),
             buffer_paths: split.buffer_paths
         };
-        buffers = split.buffers;
+        var buffers = split.buffers;
 
-        // Create un-opened comm:
-        return widget_manager._create_comm(widget_manager.comm_target_name, id);
-
-    }).then(comm => {
         var content = {
             'comm_id': id,
             'target_name': widget_manager.comm_target_name,

--- a/js/src/cameras/OrthographicCamera.js
+++ b/js/src/cameras/OrthographicCamera.js
@@ -4,7 +4,7 @@ var OrthographicCameraAutogen = require('./OrthographicCamera.autogen');
 var OrthographicCameraModel = OrthographicCameraAutogen.OrthographicCameraModel.extend({
     // push data from model to three object
     syncToThreeObj: function(force) {
-        OrthographicCameraAutogen.OrthographicCameraModel.prototype.syncToThreeObj.call(this, arguments);
+        OrthographicCameraAutogen.OrthographicCameraModel.prototype.syncToThreeObj.apply(this, arguments);
         // Always update the projection matrix after setting the attributes:
         this.obj.updateProjectionMatrix();
     }

--- a/js/src/cameras/PerspectiveCamera.js
+++ b/js/src/cameras/PerspectiveCamera.js
@@ -4,7 +4,7 @@ var PerspectiveCameraAutogen = require('./PerspectiveCamera.autogen');
 var PerspectiveCameraModel = PerspectiveCameraAutogen.PerspectiveCameraModel.extend({
     // push data from model to three object
     syncToThreeObj: function(force) {
-        PerspectiveCameraAutogen.PerspectiveCameraModel.prototype.syncToThreeObj.call(this, arguments);
+        PerspectiveCameraAutogen.PerspectiveCameraModel.prototype.syncToThreeObj.apply(this, arguments);
         // Always update the projection matrix after setting the attributes:
         this.obj.updateProjectionMatrix();
     }

--- a/js/src/core/Renderer.js
+++ b/js/src/core/Renderer.js
@@ -51,6 +51,7 @@ var RendererModel = RenderableModel.extend({
     },
 
     onChildChanged: function(model, options) {
+        RenderableModel.prototype.onChildChanged.apply(this, arguments);
         this.trigger('rerender', this, {});
     },
 
@@ -93,6 +94,21 @@ var RendererView = RenderableView.extend({
         this.listenTo(this.model, 'change:scene', this.onSceneSwitched.bind(this));
         this.listenTo(this.model, 'change:controls', this.onControlsSwitched.bind(this));
         this.listenTo(this.model, 'change:background change:background_opacity', this.applyBackground.bind(this));
+
+        var that = this;
+        function wrap(model) {
+            // Update properties for all children except the following:
+            var exclude = [
+                this.model.get('scene'),
+                this.model.get('camera'),
+                this.model.get('controls')
+            ];
+            if (exclude.indexOf(model) === -1) {
+                that.updateProperties();
+            }
+        }
+        this.listenTo(this.model, 'change', wrap);
+        this.listenTo(this.model.get('shadowMap'), 'change', wrap);
     },
 
     onCameraSwitched: function() {

--- a/js/src/lights/LightShadow.js
+++ b/js/src/lights/LightShadow.js
@@ -1,0 +1,18 @@
+var _ = require('underscore');
+var LightShadowAutogen = require('./LightShadow.autogen').LightShadowModel;
+
+var LightShadowModel = LightShadowAutogen.extend({
+
+    syncToThreeObj: function(force) {
+        if (force || this.hasChanged('mapSize')) {
+            // The map needs to be recreated!
+            this.obj.map = null;
+        }
+        LightShadowAutogen.prototype.syncToThreeObj.apply(this, arguments);
+    }
+
+});
+
+module.exports = {
+    LightShadowModel: LightShadowModel,
+};

--- a/js/src/materials/Material.js
+++ b/js/src/materials/Material.js
@@ -1,0 +1,22 @@
+var _ = require('underscore');
+var MaterialAutogen = require('./Material.autogen').MaterialModel;
+
+var MaterialModel = MaterialAutogen.extend({
+
+    onCustomMessage: function(content, buffers) {
+        switch(content.type) {
+            case 'needsUpdate':
+                this.obj.needsUpdate = true;
+                this.trigger('childchange', this);
+                break;
+            default:
+                MaterialAutogen.prototype.onCustomMessage.call(arguments);
+
+        }
+    },
+
+});
+
+module.exports = {
+    MaterialModel: MaterialModel,
+};

--- a/js/src/objects/CloneArray.js
+++ b/js/src/objects/CloneArray.js
@@ -121,7 +121,7 @@ var CloneArrayModel = CloneArrayAutogen.extend({
     syncToThreeObj: function(force) {
 
         this._needs_rebuild = false;
-        CloneArrayAutogen.prototype.syncToThreeObj.call(this, arguments);
+        CloneArrayAutogen.prototype.syncToThreeObj.apply(this, arguments);
         if (this._needs_rebuild) {
             this.obj.build();
         }

--- a/js/src/renderers/WebGLRenderer.js
+++ b/js/src/renderers/WebGLRenderer.js
@@ -19,24 +19,6 @@ var WebGLRendererModel = RenderableModel.extend({
 
         width: 200,
         height: 200,
-        autoClear: true,
-        autoClearColor: true,
-        clearColor: '#000000',
-        clearOpacity: 1.0,
-        autoClearDepth: true,
-        autoClearStencil: true,
-        sortObject: true,
-        clippingPlanes: null,
-        localClippingEnabled: false,
-        gammaFactor: 2.0,
-        gammaInput: false,
-        gammaOutput: false,
-        physicallyCorrectLights: false,
-        toneMappingExposure: 1.0,
-        toneMappingWhitePoint: 1.0,
-        maxMorphTargets: 8,
-        maxMorphNormals: 4,
-        toneMapping: 'LinearToneMapping',
 
     }),
 
@@ -75,10 +57,7 @@ var WebGLRendererView = RenderableView.extend({
 
         // We need to ensure that renderer properties are applied
         // (we have no idea where the renderer has been...)
-        var clearColor = ThreeModel.prototype.convertColorModelToThree(this.model.get('clearColor'));
-        var clearOpacity = ThreeModel.prototype.convertFloatModelToThree(this.model.get('clearOpacity'));
-        this.renderer.setClearColor(clearColor, clearOpacity);
-        // TODO: Apply other model attributes
+        this.updateProperties();
     },
 
     //

--- a/js/src/renderers/webgl/WebGLShadowMap.js
+++ b/js/src/renderers/webgl/WebGLShadowMap.js
@@ -1,0 +1,37 @@
+
+var _ = require('underscore');
+var widgets = require('@jupyter-widgets/base');
+var Promise = require('bluebird');
+
+var WebGLShadowMapAutogenModel = require('./WebGLShadowMap.autogen').WebGLShadowMapModel;
+
+
+/**
+ * Renderer child classes are different, as they map to 0 or more THREE objects,
+ * depending on how many views there are. Much of the sync logic is therefore
+ * put in the `Renderable` class instead.
+ */
+var WebGLShadowMapModel = WebGLShadowMapAutogenModel.extend({
+
+    constructThreeObject: function() {
+        // This should never be instantiated directly
+        return Promise.resolve(null);
+    },
+
+    processNewObj: function() {
+        // Leave this to Renderable
+    },
+
+    syncToThreeObj: function(force) {
+        // Leave this to Renderable
+    },
+
+    synToModel: function(syncAllProps) {
+        // Leave this to Renderable
+    },
+
+});
+
+module.exports = {
+    WebGLShadowMapModel: WebGLShadowMapModel,
+};

--- a/js/src/textures/TextTexture.js
+++ b/js/src/textures/TextTexture.js
@@ -18,7 +18,7 @@ var TextTextureModel = TextTextureBase.extend({
 
     // push data from model to three object
     syncToThreeObj: function(force) {
-        TextTextureBase.prototype.syncToThreeObj.call(this, arguments);
+        TextTextureBase.prototype.syncToThreeObj.apply(this, arguments);
 
         // TODO: Use mapping of relevant properties instead of sync?
         var canvas = this.buildCanvas();

--- a/pythreejs/_base/Three.py
+++ b/pythreejs/_base/Three.py
@@ -1,41 +1,8 @@
-from ipywidgets import DOMWidget, Widget, widget_serialization
-from traitlets import Unicode, CInt, Bool, Instance
+from ipywidgets import Widget, widget_serialization
+from traitlets import Unicode
 
 from .._package import npm_pkg_name
 from .._version import EXTENSION_VERSION
-
-
-class RenderableWidget(DOMWidget):
-    _view_module = Unicode(npm_pkg_name).tag(sync=True)
-    _model_module = Unicode(npm_pkg_name).tag(sync=True)
-    _view_module_version = Unicode(EXTENSION_VERSION).tag(sync=True)
-    _model_module_version = Unicode(EXTENSION_VERSION).tag(sync=True)
-
-    # renderer properties
-    _width = CInt(200).tag(sync=True)
-    _height = CInt(200).tag(sync=True)
-
-    def send_msg(self, message_type, payload=None):
-        if payload is None:
-            payload = {}
-        content = {
-            "type": message_type,
-            "payload": payload
-        }
-        self.send(content=content, buffers=None)
-
-    def log(self, msg):
-        content = {
-            'type': 'print',
-            'msg': msg
-        }
-        self.send(content=content, buffers=None)
-
-    def freeze(self):
-        content = {
-            "type": "freeze"
-        }
-        self.send(content)
 
 
 class ThreeWidget(Widget):
@@ -63,17 +30,5 @@ class ThreeWidget(Widget):
 
     def _ipython_display_(self, **kwargs):
         from IPython.display import display
+        from .renderable import PreviewWidget
         return display(PreviewWidget(self), **kwargs)
-
-
-class PreviewWidget(RenderableWidget):
-    # renderer properties
-    _flat = Bool(False).tag(sync=True)
-    _wire = Bool(False).tag(sync=True)
-    _model_name = Unicode('PreviewModel').tag(sync=True)
-    _view_name = Unicode('PreviewView').tag(sync=True)
-
-    child = Instance(ThreeWidget).tag(sync=True, **widget_serialization)
-
-    def __init__(self, child, **kwargs):
-        super(PreviewWidget, self).__init__(child=child, **kwargs)

--- a/pythreejs/_base/renderable.py
+++ b/pythreejs/_base/renderable.py
@@ -1,0 +1,78 @@
+from ipywidgets import DOMWidget, Widget, widget_serialization
+from traitlets import Unicode, CInt, CFloat, Enum, Bool, Instance, List
+
+from .._package import npm_pkg_name
+from .._version import EXTENSION_VERSION
+
+from .Three import ThreeWidget
+from ..enums import ToneMappings
+from ..math.Plane_autogen import Plane
+from ..renderers.webgl.WebGLShadowMap_autogen import WebGLShadowMap
+
+
+class RenderableWidget(DOMWidget):
+    _view_module = Unicode(npm_pkg_name).tag(sync=True)
+    _model_module = Unicode(npm_pkg_name).tag(sync=True)
+    _view_module_version = Unicode(EXTENSION_VERSION).tag(sync=True)
+    _model_module_version = Unicode(EXTENSION_VERSION).tag(sync=True)
+
+    # renderer properties
+    _width = CInt(200).tag(sync=True)
+    _height = CInt(200).tag(sync=True)
+    _antialias = Bool(False).tag(sync=True)
+
+    autoClear = Bool(True).tag(sync=True)
+    autoClearColor = Bool(True).tag(sync=True)
+    autoClearDepth = Bool(True).tag(sync=True)
+    autoClearStencil = Bool(True).tag(sync=True)
+    clippingPlanes = List(Instance(Plane)).tag(sync=True, **widget_serialization)
+    gammaFactor = CFloat(2.0).tag(sync=True)
+    gammaInput = Bool(False).tag(sync=True)
+    gammaOutput = Bool(False).tag(sync=True)
+    localClippingEnabled = Bool(False).tag(sync=True)
+    maxMorphTargets = CInt(8).tag(sync=True)
+    maxMorphNormals = CInt(4).tag(sync=True)
+    physicallyCorrectLights = Bool(False).tag(sync=True)
+    shadowMap = Instance(WebGLShadowMap, args=(), allow_none=True).tag(sync=True, **widget_serialization)
+    sortObject = Bool(True).tag(sync=True)
+    toneMapping = Enum(ToneMappings, 'LinearToneMapping').tag(sync=True)
+    toneMappingExposure = CFloat(1.0).tag(sync=True)
+    toneMappingWhitePoint = CFloat(1.0).tag(sync=True)
+
+    clearColor = Unicode('#000000').tag(sync=True)
+    clearOpacity = CFloat(1.0).tag(sync=True)
+
+    def send_msg(self, message_type, payload=None):
+        if payload is None:
+            payload = {}
+        content = {
+            "type": message_type,
+            "payload": payload
+        }
+        self.send(content=content, buffers=None)
+
+    def log(self, msg):
+        content = {
+            'type': 'print',
+            'msg': msg
+        }
+        self.send(content=content, buffers=None)
+
+    def freeze(self):
+        content = {
+            "type": "freeze"
+        }
+        self.send(content)
+
+
+class PreviewWidget(RenderableWidget):
+    # renderer properties
+    _flat = Bool(False).tag(sync=True)
+    _wire = Bool(False).tag(sync=True)
+    _model_name = Unicode('PreviewModel').tag(sync=True)
+    _view_name = Unicode('PreviewView').tag(sync=True)
+
+    child = Instance(ThreeWidget).tag(sync=True, **widget_serialization)
+
+    def __init__(self, child, **kwargs):
+        super(PreviewWidget, self).__init__(child=child, **kwargs)

--- a/pythreejs/core/Renderer.py
+++ b/pythreejs/core/Renderer.py
@@ -9,7 +9,7 @@ from traitlets import (
 from ..enums import *
 from ..traits import *
 
-from .._base.Three import RenderableWidget
+from .._base.renderable import RenderableWidget
 from ..scenes.Scene_autogen import Scene
 from ..cameras.Camera_autogen import Camera
 from ..controls.Controls_autogen import Controls
@@ -19,8 +19,6 @@ from_json = widget_serialization['from_json']
 
 class Renderer(RenderableWidget):
     """Renderer
-
-    Author: @vidartf
     """
 
     _view_name = Unicode('RendererView').tag(sync=True)
@@ -35,11 +33,12 @@ class Renderer(RenderableWidget):
     background = Color('black', allow_none=True).tag(sync=True)
     background_opacity = Float(1.0, min=0.0, max=1.0).tag(sync=True)
 
-    def __init__(self, scene, camera, controls=None, **kwargs):
+    def __init__(self, scene, camera, controls=None, antialias=False, **kwargs):
         super(Renderer, self).__init__(
             scene=scene,
             camera=camera,
             controls=controls or [],
+            _antialias=antialias,
             **kwargs)
         link((self, 'width'), (self, '_width'))
         link((self, 'height'), (self, '_height'))

--- a/pythreejs/materials/Material.py
+++ b/pythreejs/materials/Material.py
@@ -1,0 +1,19 @@
+
+from traitlets import Bool, validate
+from .Material_autogen import Material as MaterialAutogen
+
+
+class Material(MaterialAutogen):
+
+    # Do not sync this automatically:
+    needsUpdate = Bool(False)
+
+    @validate('needsUpdate')
+    def onNeedsUpdate(self, proposal):
+        if proposal.value:
+            content = {
+                "type": "needsUpdate",
+            }
+            self.send(content=content, buffers=None)
+        # Never actually set value
+        return False

--- a/pythreejs/renderers/WebGLRenderer.py
+++ b/pythreejs/renderers/WebGLRenderer.py
@@ -3,17 +3,16 @@ from traitlets import Unicode, Int, CInt, Enum, Instance, List, Float, CFloat, B
 
 from ..enums import ToneMappings
 
-from .._base.Three import RenderableWidget
+from .._base.renderable import RenderableWidget
 from ..math.Plane_autogen import Plane
 
 to_json = widget_serialization['to_json']
 from_json = widget_serialization['from_json']
 
+
 class WebGLRenderer(RenderableWidget):
     """WebGLRenderer
 
-    Author: @abelnation
-    Date: Wed Aug 31 2016 23:46:30 GMT-0700 (PDT)
     See http://threejs.org/docs/#api/renderers/WebGLRenderer
     """
 
@@ -22,27 +21,9 @@ class WebGLRenderer(RenderableWidget):
 
     width = CInt(200)
     height = CInt(200)
-    autoClear = Bool(True).tag(sync=True)
-    autoClearColor = Bool(True).tag(sync=True)
-    clearColor = Unicode('#000000').tag(sync=True)
-    clearOpacity = CFloat(1.0).tag(sync=True)
-    autoClearDepth = Bool(True).tag(sync=True)
-    autoClearStencil = Bool(True).tag(sync=True)
-    sortObject = Bool(True).tag(sync=True)
-    clippingPlanes = List(Instance(Plane)).tag(sync=True, **widget_serialization)
-    localClippingEnabled = Bool(False).tag(sync=True)
-    gammaFactor = CFloat(2.0).tag(sync=True)
-    gammaInput = Bool(False).tag(sync=True)
-    gammaOutput = Bool(False).tag(sync=True)
-    physicallyCorrectLights = Bool(False).tag(sync=True)
-    toneMapping = Enum(ToneMappings, 'LinearToneMapping').tag(sync=True)
-    toneMappingExposure = CFloat(1.0).tag(sync=True)
-    toneMappingWhitePoint = CFloat(1.0).tag(sync=True)
-    maxMorphTargets = CInt(8).tag(sync=True)
-    maxMorphNormals = CInt(4).tag(sync=True)
 
-    def __init__(self, **kwargs):
-        super(WebGLRenderer, self).__init__(**kwargs)
+    def __init__(self, antialias=False, **kwargs):
+        super(WebGLRenderer, self).__init__(_antialias=antialias, **kwargs)
         link((self, 'width'), (self, '_width'))
         link((self, 'height'), (self, '_height'))
 

--- a/pythreejs/traits.py
+++ b/pythreejs/traits.py
@@ -6,6 +6,8 @@ from traitlets import (
     Bool, Tuple, Undefined, TraitError, Union,
 )
 
+from ipywidgets import widget_serialization
+
 from ipydatawidgets import DataUnion, NDArrayWidget
 
 def Vector2(trait_type=CFloat, default=None, **kwargs):
@@ -74,3 +76,21 @@ class WebGLDataUnion(DataUnion):
                 # 64-bit not supported, coerce to 32-bit
                 value = value.astype('float32')
         return value
+
+
+class Uninitialized:
+    pass
+
+_widget_to_json = widget_serialization['to_json']
+
+def _serialize_uninitialized(value, owner):
+    if isinstance(value, Uninitialized):
+        return 'uninitialized'
+    return _widget_to_json(value, owner)
+
+unitialized_serialization = {
+    'to_json': _serialize_uninitialized,
+    'from_json': widget_serialization['from_json'],
+    }
+
+UninitializedSentinel = Uninitialized()


### PR DESCRIPTION
Fixes #84. Fixes #81.

Also enables rendering configs on all renderers, including antialiasing (changing this requires a new webgl context, so the renderer pool had to be updated to support this).