### PR TITLE
Update autogen related commands in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ The relevant commands while working on the repository are included below. These 
 # To perform initial dev setup, run:
 pip install -e .
 
+# All commands below assume to be in the ./js/ directory
+cd ./js/
+
 # To re-generate autogen files, run:
 npm run autogen
 
 # To build and install distribution files, run:
-npm run build
+npm run build:all
 jupyter nbextension install --py --symlink --sys-prefix pythreejs
 
 # To clean out generated files, run:


### PR DESCRIPTION
For me it wasn't obvious I need to be in the `./js/` dir for the `npm` commands. Otherwise you get an error about a missing `package.json`.

Also I had to change `build` to `build:all` (or any of the other scripts defined `package.json`).
