### PR TITLE
Ensure examples pass non-lax nbval test

### DIFF
--- a/examples/Animation.ipynb
+++ b/examples/Animation.ipynb
@@ -152,12 +152,16 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "421de1b8aa2d425e8315141888f2bee8",
+       "model_id": "e7bb1ceb498a400e8b59b11725e073be",
        "version_major": 2,
        "version_minor": 0
       },
@@ -177,7 +181,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "Renderer(camera=PerspectiveCamera(aspect=1.5, position=(10.0, 6.0, 10.0), projectionMatrix=(1.4296712803397058, 0.0, 0.0, 0.0, 0.0, 2.1445069205095586, 0.0, 0.0, 0.0, 0.0, -1.00010000500025, -1.0, 0.0, 0.0, -0.200010000500025, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='PerspectiveCamera', up=(0.0, 1.0, 0.0)), controls=[OrbitControls(controlling=PerspectiveCamera(aspect=1.5, position=(10.0, 6.0, 10.0), projectionMatrix=(1.4296712803397058, 0.0, 0.0, 0.0, 0.0, 2.1445069205095586, 0.0, 0.0, 0.0, 0.0, -1.00010000500025, -1.0, 0.0, 0.0, -0.200010000500025, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='PerspectiveCamera', up=(0.0, 1.0, 0.0)))], scene=Scene(children=(Mesh(geometry=SphereBufferGeometry(heightSegments=16, radius=1.0, type='SphereBufferGeometry', widthSegments=32), material=MeshStandardMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='red', defines={'STANDARD': ''}, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, metalnessMap=None, normalMap=None, normalScale=(1.0, 1.0), roughnessMap=None, type='MeshStandardMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Mesh', up=(0.0, 1.0, 0.0)), Mesh(geometry=BoxBufferGeometry(depth=1.0, height=1.0, type='BoxBufferGeometry', width=1.0), material=MeshPhysicalMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='green', defines={'PHYSICAL': ''}, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, metalnessMap=None, normalMap=None, normalScale=(1.0, 1.0), roughnessMap=None, type='MeshPhysicalMaterial'), position=(2.0, 0.0, 4.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Mesh', up=(0.0, 1.0, 0.0)), PerspectiveCamera(aspect=1.5, position=(10.0, 6.0, 10.0), projectionMatrix=(1.4296712803397058, 0.0, 0.0, 0.0, 0.0, 2.1445069205095586, 0.0, 0.0, 0.0, 0.0, -1.00010000500025, -1.0, 0.0, 0.0, -0.200010000500025, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='PerspectiveCamera', up=(0.0, 1.0, 0.0)), DirectionalLight(matrixWorldNeedsUpdate=True, position=(0.0, 10.0, 10.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), shadow=DirectionalLightShadow(camera=OrthographicCamera(bottom=-5.0, far=500.0, left=-5.0, near=0.5, projectionMatrix=(0.2, 0.0, 0.0, 0.0, 0.0, 0.2, 0.0, 0.0, 0.0, 0.0, -0.004004004004004004, 0.0, 0.0, 0.0, -1.002002002002002, 1.0), quaternion=(0.0, 0.0, 0.0, 1.0), right=5.0, scale=(1.0, 1.0, 1.0), top=5.0, type='OrthographicCamera', up=(0.0, 1.0, 0.0)), mapSize=(512.0, 512.0)), target=Object3D(quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Object3D', up=(0.0, 1.0, 0.0)), type='DirectionalLight', up=(0.0, 1.0, 0.0)), AmbientLight(quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='AmbientLight', up=(0.0, 1.0, 0.0))), fog=None, overrideMaterial=None, quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Scene', up=(0.0, 1.0, 0.0)), shadowMap=WebGLShadowMap())"
+       "Renderer(camera=PerspectiveCamera(aspect=1.5, position=(10.0, 6.0, 10.0), projectionMatrix=(1.4296712803397058, 0.0, 0.0, 0.0, 0.0, 2.1445069205095586, 0.0, 0.0, 0.0, 0.0, -1.00010000500025, -1.0, 0.0, 0.0, -0.200010000500025, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), controls=[OrbitControls(controlling=PerspectiveCamera(aspect=1.5, position=(10.0, 6.0, 10.0), projectionMatrix=(1.4296712803397058, 0.0, 0.0, 0.0, 0.0, 2.1445069205095586, 0.0, 0.0, 0.0, 0.0, -1.00010000500025, -1.0, 0.0, 0.0, -0.200010000500025, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)))], scene=Scene(children=(Mesh(geometry=SphereBufferGeometry(heightSegments=16, widthSegments=32), material=MeshStandardMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='red', defines={'STANDARD': ''}, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, metalnessMap=None, normalMap=None, normalScale=(1.0, 1.0), roughnessMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Mesh(geometry=BoxBufferGeometry(), material=MeshPhysicalMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='green', defines={'PHYSICAL': ''}, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, metalnessMap=None, normalMap=None, normalScale=(1.0, 1.0), roughnessMap=None), position=(2.0, 0.0, 4.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), PerspectiveCamera(aspect=1.5, position=(10.0, 6.0, 10.0), projectionMatrix=(1.4296712803397058, 0.0, 0.0, 0.0, 0.0, 2.1445069205095586, 0.0, 0.0, 0.0, 0.0, -1.00010000500025, -1.0, 0.0, 0.0, -0.200010000500025, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), DirectionalLight(matrixWorldNeedsUpdate=True, position=(0.0, 10.0, 10.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), shadow=DirectionalLightShadow(camera=OrthographicCamera(bottom=-5.0, far=500.0, left=-5.0, near=0.5, projectionMatrix=(0.2, 0.0, 0.0, 0.0, 0.0, 0.2, 0.0, 0.0, 0.0, 0.0, -0.004004004004004004, 0.0, 0.0, 0.0, -1.002002002002002, 1.0), quaternion=(0.0, 0.0, 0.0, 1.0), right=5.0, scale=(1.0, 1.0, 1.0), top=5.0, up=(0.0, 1.0, 0.0)), mapSize=(512.0, 512.0)), target=Object3D(quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), up=(0.0, 1.0, 0.0)), AmbientLight(quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0))), fog=None, overrideMaterial=None, quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), shadowMap=WebGLShadowMap())"
       ]
      },
      "metadata": {},
@@ -191,12 +195,16 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "002b7b03200748d3b4d62a38c383f4e3",
+       "model_id": "c5a814d39f1c43b5913e5d2a7a83179b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -216,10 +224,10 @@
        "</p>\n"
       ],
       "text/plain": [
-       "AnimationAction(clip=AnimationClip(duration=5.0, tracks=(VectorKeyframeTrack(name='.position', times=array([0, 2, 5]), values=array([ 10.        ,   6.        ,  10.        ,   6.30000019,\n",
-       "         3.77999997,   6.30000019,  -2.98000002,   0.83999997,   9.19999981], dtype=float32)), QuaternionKeyframeTrack(name='.quaternion', times=array([0, 2, 5]), values=array([-0.184     ,  0.375     ,  0.0762    ,  0.90499997, -0.184     ,\n",
-       "        0.375     ,  0.0762    ,  0.90499997, -0.043     , -0.156     ,\n",
-       "       -0.00681   ,  0.98699999], dtype=float32)))), localRoot=PerspectiveCamera(aspect=1.5, position=(10.0, 6.0, 10.0), projectionMatrix=(1.4296712803397058, 0.0, 0.0, 0.0, 0.0, 2.1445069205095586, 0.0, 0.0, 0.0, 0.0, -1.00010000500025, -1.0, 0.0, 0.0, -0.200010000500025, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='PerspectiveCamera', up=(0.0, 1.0, 0.0)), mixer=AnimationMixer(rootObject=PerspectiveCamera(aspect=1.5, position=(10.0, 6.0, 10.0), projectionMatrix=(1.4296712803397058, 0.0, 0.0, 0.0, 0.0, 2.1445069205095586, 0.0, 0.0, 0.0, 0.0, -1.00010000500025, -1.0, 0.0, 0.0, -0.200010000500025, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='PerspectiveCamera', up=(0.0, 1.0, 0.0))))"
+       "AnimationAction(clip=AnimationClip(duration=5.0, tracks=(VectorKeyframeTrack(name='.position', times=array([0, 2, 5]), values=array([10.  ,  6.  , 10.  ,  6.3 ,  3.78,  6.3 , -2.98,  0.84,  9.2 ],\n",
+       "      dtype=float32)), QuaternionKeyframeTrack(name='.quaternion', times=array([0, 2, 5]), values=array([-0.184  ,  0.375  ,  0.0762 ,  0.905  , -0.184  ,  0.375  ,\n",
+       "        0.0762 ,  0.905  , -0.043  , -0.156  , -0.00681,  0.987  ],\n",
+       "      dtype=float32)))), localRoot=PerspectiveCamera(aspect=1.5, position=(10.0, 6.0, 10.0), projectionMatrix=(1.4296712803397058, 0.0, 0.0, 0.0, 0.0, 2.1445069205095586, 0.0, 0.0, 0.0, 0.0, -1.00010000500025, -1.0, 0.0, 0.0, -0.200010000500025, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), mixer=AnimationMixer(rootObject=PerspectiveCamera(aspect=1.5, position=(10.0, 6.0, 10.0), projectionMatrix=(1.4296712803397058, 0.0, 0.0, 0.0, 0.0, 2.1445069205095586, 0.0, 0.0, 0.0, 0.0, -1.00010000500025, -1.0, 0.0, 0.0, -0.200010000500025, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0))))"
       ]
      },
      "metadata": {},
@@ -258,7 +266,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7e366662527d4c85bed775032c5836bd",
+       "model_id": "dd0b2b8c072240fdbda967972cb2f55f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -278,7 +286,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "AnimationAction(clip=AnimationClip(duration=1.5, tracks=(ColorKeyframeTrack(name='.material.color', times=array([0, 1]), values=array([1, 0, 0, 0, 0, 1])),)), localRoot=Mesh(geometry=SphereBufferGeometry(heightSegments=16, radius=1.0, type='SphereBufferGeometry', widthSegments=32), material=MeshStandardMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='red', defines={'STANDARD': ''}, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, metalnessMap=None, normalMap=None, normalScale=(1.0, 1.0), roughnessMap=None, type='MeshStandardMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Mesh', up=(0.0, 1.0, 0.0)), mixer=AnimationMixer(rootObject=Mesh(geometry=SphereBufferGeometry(heightSegments=16, radius=1.0, type='SphereBufferGeometry', widthSegments=32), material=MeshStandardMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='red', defines={'STANDARD': ''}, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, metalnessMap=None, normalMap=None, normalScale=(1.0, 1.0), roughnessMap=None, type='MeshStandardMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Mesh', up=(0.0, 1.0, 0.0))))"
+       "AnimationAction(clip=AnimationClip(duration=1.5, tracks=(ColorKeyframeTrack(name='.material.color', times=array([0, 1]), values=array([1, 0, 0, 0, 0, 1])),)), localRoot=Mesh(geometry=SphereBufferGeometry(heightSegments=16, widthSegments=32), material=MeshStandardMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='red', defines={'STANDARD': ''}, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, metalnessMap=None, normalMap=None, normalScale=(1.0, 1.0), roughnessMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), mixer=AnimationMixer(rootObject=Mesh(geometry=SphereBufferGeometry(heightSegments=16, widthSegments=32), material=MeshStandardMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='red', defines={'STANDARD': ''}, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, metalnessMap=None, normalMap=None, normalScale=(1.0, 1.0), roughnessMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0))))"
       ]
      },
      "metadata": {},
@@ -313,7 +321,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a35f1d6394814350a868e004fa1d49be",
+       "model_id": "35e34a65ed8d413f930c9209fec1cda0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -377,7 +385,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d71a1a561a4f449c9949369d77bad859",
+       "model_id": "dc28a62ee6f44e31822b2f4270e607a0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -397,7 +405,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "AnimationAction(clip=AnimationClip(tracks=(NumberKeyframeTrack(name='.rotation[y]', times=array([0, 2]), values=array([ 0.        ,  6.28000021], dtype=float32)),)), localRoot=Group(children=(Mesh(geometry=ParametricGeometry(func='\\nfunction f(origu,origv) {\\n    // scale u and v to the ranges I want: [0, 2*pi]\\n    var u = 2*Math.PI*origu;\\n    var v = 2*Math.PI*origv;\\n    \\n    var x = Math.sin(u);\\n    var y = Math.cos(v);\\n    var z = Math.cos(u+v);\\n    \\n    return new THREE.Vector3(x,y,z)\\n}\\n', slices=16, stacks=16, type='ParametricGeometry'), material=MeshLambertMaterial(alphaMap=None, aoMap=None, color='green', emissiveMap=None, envMap=None, lightMap=None, map=None, specularMap=None, type='MeshLambertMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Mesh', up=(0.0, 1.0, 0.0)), Mesh(geometry=ParametricGeometry(func='\\nfunction f(origu,origv) {\\n    // scale u and v to the ranges I want: [0, 2*pi]\\n    var u = 2*Math.PI*origu;\\n    var v = 2*Math.PI*origv;\\n    \\n    var x = Math.sin(u);\\n    var y = Math.cos(v);\\n    var z = Math.cos(u+v);\\n    \\n    return new THREE.Vector3(x,y,z)\\n}\\n', slices=16, stacks=16, type='ParametricGeometry'), material=MeshLambertMaterial(alphaMap=None, aoMap=None, color='yellow', emissiveMap=None, envMap=None, lightMap=None, map=None, side='BackSide', specularMap=None, type='MeshLambertMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Mesh', up=(0.0, 1.0, 0.0))), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Group', up=(0.0, 1.0, 0.0)), mixer=AnimationMixer(rootObject=Group(children=(Mesh(geometry=ParametricGeometry(func='\\nfunction f(origu,origv) {\\n    // scale u and v to the ranges I want: [0, 2*pi]\\n    var u = 2*Math.PI*origu;\\n    var v = 2*Math.PI*origv;\\n    \\n    var x = Math.sin(u);\\n    var y = Math.cos(v);\\n    var z = Math.cos(u+v);\\n    \\n    return new THREE.Vector3(x,y,z)\\n}\\n', slices=16, stacks=16, type='ParametricGeometry'), material=MeshLambertMaterial(alphaMap=None, aoMap=None, color='green', emissiveMap=None, envMap=None, lightMap=None, map=None, specularMap=None, type='MeshLambertMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Mesh', up=(0.0, 1.0, 0.0)), Mesh(geometry=ParametricGeometry(func='\\nfunction f(origu,origv) {\\n    // scale u and v to the ranges I want: [0, 2*pi]\\n    var u = 2*Math.PI*origu;\\n    var v = 2*Math.PI*origv;\\n    \\n    var x = Math.sin(u);\\n    var y = Math.cos(v);\\n    var z = Math.cos(u+v);\\n    \\n    return new THREE.Vector3(x,y,z)\\n}\\n', slices=16, stacks=16, type='ParametricGeometry'), material=MeshLambertMaterial(alphaMap=None, aoMap=None, color='yellow', emissiveMap=None, envMap=None, lightMap=None, map=None, side='BackSide', specularMap=None, type='MeshLambertMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Mesh', up=(0.0, 1.0, 0.0))), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Group', up=(0.0, 1.0, 0.0))))"
+       "AnimationAction(clip=AnimationClip(tracks=(NumberKeyframeTrack(name='.rotation[y]', times=array([0, 2]), values=array([0.  , 6.28], dtype=float32)),)), localRoot=Group(children=(Mesh(geometry=ParametricGeometry(func='\\nfunction f(origu,origv) {\\n    // scale u and v to the ranges I want: [0, 2*pi]\\n    var u = 2*Math.PI*origu;\\n    var v = 2*Math.PI*origv;\\n    \\n    var x = Math.sin(u);\\n    var y = Math.cos(v);\\n    var z = Math.cos(u+v);\\n    \\n    return new THREE.Vector3(x,y,z)\\n}\\n', slices=16, stacks=16), material=MeshLambertMaterial(alphaMap=None, aoMap=None, color='green', emissiveMap=None, envMap=None, lightMap=None, map=None, specularMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Mesh(geometry=ParametricGeometry(func='\\nfunction f(origu,origv) {\\n    // scale u and v to the ranges I want: [0, 2*pi]\\n    var u = 2*Math.PI*origu;\\n    var v = 2*Math.PI*origv;\\n    \\n    var x = Math.sin(u);\\n    var y = Math.cos(v);\\n    var z = Math.cos(u+v);\\n    \\n    return new THREE.Vector3(x,y,z)\\n}\\n', slices=16, stacks=16), material=MeshLambertMaterial(alphaMap=None, aoMap=None, color='yellow', emissiveMap=None, envMap=None, lightMap=None, map=None, side='BackSide', specularMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0))), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), mixer=AnimationMixer(rootObject=Group(children=(Mesh(geometry=ParametricGeometry(func='\\nfunction f(origu,origv) {\\n    // scale u and v to the ranges I want: [0, 2*pi]\\n    var u = 2*Math.PI*origu;\\n    var v = 2*Math.PI*origv;\\n    \\n    var x = Math.sin(u);\\n    var y = Math.cos(v);\\n    var z = Math.cos(u+v);\\n    \\n    return new THREE.Vector3(x,y,z)\\n}\\n', slices=16, stacks=16), material=MeshLambertMaterial(alphaMap=None, aoMap=None, color='green', emissiveMap=None, envMap=None, lightMap=None, map=None, specularMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Mesh(geometry=ParametricGeometry(func='\\nfunction f(origu,origv) {\\n    // scale u and v to the ranges I want: [0, 2*pi]\\n    var u = 2*Math.PI*origu;\\n    var v = 2*Math.PI*origv;\\n    \\n    var x = Math.sin(u);\\n    var y = Math.cos(v);\\n    var z = Math.cos(u+v);\\n    \\n    return new THREE.Vector3(x,y,z)\\n}\\n', slices=16, stacks=16), material=MeshLambertMaterial(alphaMap=None, aoMap=None, color='yellow', emissiveMap=None, envMap=None, lightMap=None, map=None, side='BackSide', specularMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0))), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0))))"
       ]
      },
      "metadata": {},
@@ -496,7 +504,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "48fcb06537f947ce9612c9e5eb40f45e",
+       "model_id": "161ed1e8f9384df786bb06960c064b63",
        "version_major": 2,
        "version_minor": 0
       },
@@ -516,31 +524,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "Renderer(camera=PerspectiveCamera(aspect=1.5, position=(5.0, 3.0, 5.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), controls=[OrbitControls(controlling=PerspectiveCamera(aspect=1.5, position=(5.0, 3.0, 5.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)))], scene=Scene(children=(Mesh(geometry=BufferGeometry(attributes={'position': BufferAttribute(array=array([[ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       ..., \n",
-       "       [ -1.13142611e-16,  -1.00000000e+00,  -4.68652047e-17],\n",
-       "       [ -1.20111562e-16,  -1.00000000e+00,  -2.38916744e-17],\n",
-       "       [ -1.22464685e-16,  -1.00000000e+00,  -2.99951951e-32]], dtype=float32), normalized=False, version=0), 'normal': BufferAttribute(array=array([[ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       ..., \n",
-       "       [ -1.13142611e-16,  -1.00000000e+00,  -4.68652047e-17],\n",
-       "       [ -1.20111562e-16,  -1.00000000e+00,  -2.38916744e-17],\n",
-       "       [ -1.22464685e-16,  -1.00000000e+00,  -2.99951951e-32]], dtype=float32), normalized=False, version=0), 'uv': BufferAttribute(array=array([[ 0.     ,  1.     ],\n",
-       "       [ 0.03125,  1.     ],\n",
-       "       [ 0.0625 ,  1.     ],\n",
-       "       ..., \n",
-       "       [ 0.9375 ,  0.     ],\n",
-       "       [ 0.96875,  0.     ],\n",
-       "       [ 1.     ,  0.     ]], dtype=float32), normalized=False, version=0)}, morphAttributes={'position': (BufferAttribute(array=array([[ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       ..., \n",
-       "       [ -1.13142611e-16,  -1.00000000e+00,  -4.68652047e-17],\n",
-       "       [ -1.20111562e-16,  -1.00000000e+00,  -2.38916744e-17],\n",
-       "       [ -1.22464685e-16,  -1.00000000e+00,  -2.99951951e-32]], dtype=float32), version=1),)}, type='BufferGeometry'), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='#ff3333', displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, morphTargets=True, normalMap=None, normalScale=(1.0, 1.0), shininess=150.0, specularMap=None, type='MeshPhongMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Mesh', up=(0.0, 1.0, 0.0)), PerspectiveCamera(aspect=1.5, position=(5.0, 3.0, 5.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), DirectionalLight(intensity=0.6, position=(3.0, 5.0, 1.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), AmbientLight(intensity=0.5, quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0))), fog=None, overrideMaterial=None, quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), shadowMap=WebGLShadowMap())"
+       "Renderer(camera=PerspectiveCamera(aspect=1.5, position=(5.0, 3.0, 5.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), controls=[OrbitControls(controlling=PerspectiveCamera(aspect=1.5, position=(5.0, 3.0, 5.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)))], scene=Scene(children=(Mesh(geometry=BufferGeometry(attributes={'position': <BufferAttribute shape=(561, 3), dtype=float32>, 'normal': <BufferAttribute shape=(561, 3), dtype=float32>, 'uv': <BufferAttribute shape=(561, 2), dtype=float32>}, morphAttributes={'position': <BufferAttribute shape=(561, 3), dtype=float32>}), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='#ff3333', displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, morphTargets=True, normalMap=None, normalScale=(1.0, 1.0), shininess=150.0, specularMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), PerspectiveCamera(aspect=1.5, position=(5.0, 3.0, 5.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), DirectionalLight(intensity=0.6, position=(3.0, 5.0, 1.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), AmbientLight(intensity=0.5, quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0))), fog=None, overrideMaterial=None, quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), shadowMap=WebGLShadowMap())"
       ]
      },
      "metadata": {},
@@ -549,7 +533,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a7fa5488efef44cc86593927208bc6f8",
+       "model_id": "f61d2da9bc71495c9a35abb24e81beea",
        "version_major": 2,
        "version_minor": 0
       },
@@ -569,55 +553,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "AnimationAction(clip=AnimationClip(duration=3.0, tracks=(NumberKeyframeTrack(name='.morphTargetInfluences[0]', times=array([ 0. ,  1.5,  3. ], dtype=float32), values=array([ 0. ,  2.5,  0. ], dtype=float32)),)), localRoot=Mesh(geometry=BufferGeometry(attributes={'position': BufferAttribute(array=array([[ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       ..., \n",
-       "       [ -1.13142611e-16,  -1.00000000e+00,  -4.68652047e-17],\n",
-       "       [ -1.20111562e-16,  -1.00000000e+00,  -2.38916744e-17],\n",
-       "       [ -1.22464685e-16,  -1.00000000e+00,  -2.99951951e-32]], dtype=float32), normalized=False, version=0), 'normal': BufferAttribute(array=array([[ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       ..., \n",
-       "       [ -1.13142611e-16,  -1.00000000e+00,  -4.68652047e-17],\n",
-       "       [ -1.20111562e-16,  -1.00000000e+00,  -2.38916744e-17],\n",
-       "       [ -1.22464685e-16,  -1.00000000e+00,  -2.99951951e-32]], dtype=float32), normalized=False, version=0), 'uv': BufferAttribute(array=array([[ 0.     ,  1.     ],\n",
-       "       [ 0.03125,  1.     ],\n",
-       "       [ 0.0625 ,  1.     ],\n",
-       "       ..., \n",
-       "       [ 0.9375 ,  0.     ],\n",
-       "       [ 0.96875,  0.     ],\n",
-       "       [ 1.     ,  0.     ]], dtype=float32), normalized=False, version=0)}, morphAttributes={'position': (BufferAttribute(array=array([[ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       ..., \n",
-       "       [ -1.13142611e-16,  -1.00000000e+00,  -4.68652047e-17],\n",
-       "       [ -1.20111562e-16,  -1.00000000e+00,  -2.38916744e-17],\n",
-       "       [ -1.22464685e-16,  -1.00000000e+00,  -2.99951951e-32]], dtype=float32), version=1),)}, type='BufferGeometry'), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='#ff3333', displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, morphTargets=True, normalMap=None, normalScale=(1.0, 1.0), shininess=150.0, specularMap=None, type='MeshPhongMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Mesh', up=(0.0, 1.0, 0.0)), mixer=AnimationMixer(rootObject=Mesh(geometry=BufferGeometry(attributes={'position': BufferAttribute(array=array([[ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       ..., \n",
-       "       [ -1.13142611e-16,  -1.00000000e+00,  -4.68652047e-17],\n",
-       "       [ -1.20111562e-16,  -1.00000000e+00,  -2.38916744e-17],\n",
-       "       [ -1.22464685e-16,  -1.00000000e+00,  -2.99951951e-32]], dtype=float32), normalized=False, version=0), 'normal': BufferAttribute(array=array([[ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       ..., \n",
-       "       [ -1.13142611e-16,  -1.00000000e+00,  -4.68652047e-17],\n",
-       "       [ -1.20111562e-16,  -1.00000000e+00,  -2.38916744e-17],\n",
-       "       [ -1.22464685e-16,  -1.00000000e+00,  -2.99951951e-32]], dtype=float32), normalized=False, version=0), 'uv': BufferAttribute(array=array([[ 0.     ,  1.     ],\n",
-       "       [ 0.03125,  1.     ],\n",
-       "       [ 0.0625 ,  1.     ],\n",
-       "       ..., \n",
-       "       [ 0.9375 ,  0.     ],\n",
-       "       [ 0.96875,  0.     ],\n",
-       "       [ 1.     ,  0.     ]], dtype=float32), normalized=False, version=0)}, morphAttributes={'position': (BufferAttribute(array=array([[ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       [ -0.00000000e+00,   1.00000000e+00,   0.00000000e+00],\n",
-       "       ..., \n",
-       "       [ -1.13142611e-16,  -1.00000000e+00,  -4.68652047e-17],\n",
-       "       [ -1.20111562e-16,  -1.00000000e+00,  -2.38916744e-17],\n",
-       "       [ -1.22464685e-16,  -1.00000000e+00,  -2.99951951e-32]], dtype=float32), version=1),)}, type='BufferGeometry'), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='#ff3333', displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, morphTargets=True, normalMap=None, normalScale=(1.0, 1.0), shininess=150.0, specularMap=None, type='MeshPhongMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Mesh', up=(0.0, 1.0, 0.0))))"
+       "AnimationAction(clip=AnimationClip(duration=3.0, tracks=(NumberKeyframeTrack(name='.morphTargetInfluences[0]', times=array([0. , 1.5, 3. ], dtype=float32), values=array([0. , 2.5, 0. ], dtype=float32)),)), localRoot=Mesh(geometry=BufferGeometry(attributes={'position': <BufferAttribute shape=(561, 3), dtype=float32>, 'normal': <BufferAttribute shape=(561, 3), dtype=float32>, 'uv': <BufferAttribute shape=(561, 2), dtype=float32>}, morphAttributes={'position': <BufferAttribute shape=(561, 3), dtype=float32>}), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='#ff3333', displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, morphTargets=True, normalMap=None, normalScale=(1.0, 1.0), shininess=150.0, specularMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), mixer=AnimationMixer(rootObject=Mesh(geometry=BufferGeometry(attributes={'position': <BufferAttribute shape=(561, 3), dtype=float32>, 'normal': <BufferAttribute shape=(561, 3), dtype=float32>, 'uv': <BufferAttribute shape=(561, 2), dtype=float32>}, morphAttributes={'position': <BufferAttribute shape=(561, 3), dtype=float32>}), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, color='#ff3333', displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, morphTargets=True, normalMap=None, normalScale=(1.0, 1.0), shininess=150.0, specularMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0))))"
       ]
      },
      "metadata": {},
@@ -646,42 +582,51 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-skip"
+    ]
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
     "N_BONES = 3\n",
     "\n",
-    "ref_cylinder = CylinderGeometry(5, 5, 50, 5, N_BONES * 5, True)\n",
-    "cylinder = Geometry.from_geometry(ref_cylinder)"
+    "ref_cylinder = CylinderBufferGeometry(5, 5, 50, 5, N_BONES * 5, True)\n",
+    "cylinder = BufferGeometry.from_geometry(ref_cylinder)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-skip"
+    ]
+   },
    "outputs": [],
    "source": [
     "skinIndices = []\n",
     "skinWeights = []\n",
-    "\n",
-    "vertices = cylinder.vertices\n",
+    "vertices = cylinder.attributes['position'].array\n",
     "boneHeight = ref_cylinder.height / (N_BONES - 1)\n",
-    "for i in range(len(vertices)):\n",
+    "for i in range(vertices.shape[0]):\n",
     "\n",
-    "    vertex = vertices[i];\n",
-    "    y = vertex[1] + 0.5 * ref_cylinder.height\n",
+    "    y = vertices[i, 1] + 0.5 * ref_cylinder.height\n",
     "\n",
-    "    skinIndex = y // boneHeight;\n",
-    "    skinWeight = ( y % boneHeight ) / boneHeight;\n",
+    "    skinIndex = y // boneHeight\n",
+    "    skinWeight = ( y % boneHeight ) / boneHeight\n",
     "\n",
     "    # Ease between each bone\n",
     "    skinIndices.append([skinIndex, skinIndex + 1, 0, 0 ])\n",
     "    skinWeights.append([1 - skinWeight, skinWeight, 0, 0 ])\n",
     "\n",
-    "cylinder.skinIndices = skinIndices\n",
-    "cylinder.skinWeights = skinWeights\n",
+    "cylinder.attributes = dict(\n",
+    "    cylinder.attributes,\n",
+    "    skinIndex=BufferAttribute(skinIndices),\n",
+    "    skinWeight=BufferAttribute(skinWeights),\n",
+    ")\n",
     "\n",
     "shoulder = Bone(position=(0, -25, 0))\n",
     "elbow = Bone(position=(0, 25, 0))\n",
@@ -700,7 +645,11 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-skip"
+    ]
+   },
    "outputs": [],
    "source": [
     "helper = SkeletonHelper(mesh)"
@@ -716,7 +665,11 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-skip"
+    ]
+   },
    "outputs": [],
    "source": [
     "# Rotate on x and z axes:\n",
@@ -742,12 +695,16 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-skip"
+    ]
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bb383be0d09e42be9e0a9c1d13dcde3d",
+       "model_id": "78fcabb17e544cedb98e2da04d39833a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -767,7 +724,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "Renderer(camera=PerspectiveCamera(aspect=1.5, position=(40.0, 24.0, 40.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), controls=[OrbitControls(controlling=PerspectiveCamera(aspect=1.5, position=(40.0, 24.0, 40.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)))], scene=Scene(children=(SkinnedMesh(children=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), geometry=Geometry(colors=['#ffffff']), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, normalMap=None, normalScale=(1.0, 1.0), side='DoubleSide', skinning=True, specularMap=None, type='MeshPhongMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), skeleton=Skeleton(bones=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)), Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)), Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)))), type='SkinnedMesh', up=(0.0, 1.0, 0.0)), SkeletonHelper(quaternion=(0.0, 0.0, 0.0, 1.0), root=SkinnedMesh(children=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), geometry=Geometry(colors=['#ffffff']), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, normalMap=None, normalScale=(1.0, 1.0), side='DoubleSide', skinning=True, specularMap=None, type='MeshPhongMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), skeleton=Skeleton(bones=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)), Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)), Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)))), type='SkinnedMesh', up=(0.0, 1.0, 0.0)), scale=(1.0, 1.0, 1.0), type='LineSegments', up=(0.0, 1.0, 0.0)), PerspectiveCamera(aspect=1.5, position=(40.0, 24.0, 40.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), DirectionalLight(intensity=0.6, position=(3.0, 5.0, 1.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), AmbientLight(intensity=0.5, quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0))), fog=None, overrideMaterial=None, quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), shadowMap=WebGLShadowMap())"
+       "Renderer(camera=PerspectiveCamera(aspect=1.5, position=(40.0, 24.0, 40.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), controls=[OrbitControls(controlling=PerspectiveCamera(aspect=1.5, position=(40.0, 24.0, 40.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)))], scene=Scene(children=(SkinnedMesh(children=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), geometry=BufferGeometry(attributes={'position': <BufferAttribute shape=(96, 3), dtype=float32>, 'normal': <BufferAttribute shape=(96, 3), dtype=float32>, 'uv': <BufferAttribute shape=(96, 2), dtype=float32>, 'skinIndex': <BufferAttribute shape=(96, 4), dtype=float32>, 'skinWeight': <BufferAttribute shape=(96, 4), dtype=float32>}), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, normalMap=None, normalScale=(1.0, 1.0), side='DoubleSide', skinning=True, specularMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), skeleton=Skeleton(bones=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)))), up=(0.0, 1.0, 0.0)), SkeletonHelper(quaternion=(0.0, 0.0, 0.0, 1.0), root=SkinnedMesh(children=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), geometry=BufferGeometry(attributes={'position': <BufferAttribute shape=(96, 3), dtype=float32>, 'normal': <BufferAttribute shape=(96, 3), dtype=float32>, 'uv': <BufferAttribute shape=(96, 2), dtype=float32>, 'skinIndex': <BufferAttribute shape=(96, 4), dtype=float32>, 'skinWeight': <BufferAttribute shape=(96, 4), dtype=float32>}), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, normalMap=None, normalScale=(1.0, 1.0), side='DoubleSide', skinning=True, specularMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), skeleton=Skeleton(bones=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)))), up=(0.0, 1.0, 0.0)), scale=(1.0, 1.0, 1.0), type='LineSegments', up=(0.0, 1.0, 0.0)), PerspectiveCamera(aspect=1.5, position=(40.0, 24.0, 40.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), DirectionalLight(intensity=0.6, position=(3.0, 5.0, 1.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), AmbientLight(intensity=0.5, quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0))), fog=None, overrideMaterial=None, quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), shadowMap=WebGLShadowMap())"
       ]
      },
      "metadata": {},
@@ -787,12 +744,16 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-skip"
+    ]
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e78c9e4fb3244ba4aa981bf687466cf3",
+       "model_id": "303930afa87e4508b915e1610f5365e3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -812,7 +773,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "AnimationAction(clip=AnimationClip(duration=2.0, tracks=(NumberKeyframeTrack(name='.bones[1].rotation[x]', times=array([ 0. ,  0.5,  1.5,  2. ], dtype=float32), values=array([ 0.        ,  0.30000001, -0.30000001,  0.        ], dtype=float32)), NumberKeyframeTrack(name='.bones[1].rotation[z]', times=array([ 0. ,  0.5,  1.5,  2. ], dtype=float32), values=array([ 0.        ,  0.30000001, -0.30000001,  0.        ], dtype=float32)), NumberKeyframeTrack(name='.bones[2].rotation[x]', times=array([ 0. ,  0.5,  1.5,  2. ], dtype=float32), values=array([ 0.        , -0.30000001,  0.30000001,  0.        ], dtype=float32)), NumberKeyframeTrack(name='.bones[2].rotation[z]', times=array([ 0. ,  0.5,  1.5,  2. ], dtype=float32), values=array([ 0.        , -0.30000001,  0.30000001,  0.        ], dtype=float32)))), localRoot=SkinnedMesh(children=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), geometry=Geometry(colors=['#ffffff']), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, normalMap=None, normalScale=(1.0, 1.0), side='DoubleSide', skinning=True, specularMap=None, type='MeshPhongMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), skeleton=Skeleton(bones=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)), Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)), Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)))), type='SkinnedMesh', up=(0.0, 1.0, 0.0)), mixer=AnimationMixer(rootObject=SkinnedMesh(children=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), geometry=Geometry(colors=['#ffffff']), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, normalMap=None, normalScale=(1.0, 1.0), side='DoubleSide', skinning=True, specularMap=None, type='MeshPhongMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), skeleton=Skeleton(bones=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)), Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)), Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)))), type='SkinnedMesh', up=(0.0, 1.0, 0.0))))"
+       "AnimationAction(clip=AnimationClip(duration=2.0, tracks=(NumberKeyframeTrack(name='.bones[1].rotation[x]', times=array([0. , 0.5, 1.5, 2. ], dtype=float32), values=array([ 0. ,  0.3, -0.3,  0. ], dtype=float32)), NumberKeyframeTrack(name='.bones[1].rotation[z]', times=array([0. , 0.5, 1.5, 2. ], dtype=float32), values=array([ 0. ,  0.3, -0.3,  0. ], dtype=float32)), NumberKeyframeTrack(name='.bones[2].rotation[x]', times=array([0. , 0.5, 1.5, 2. ], dtype=float32), values=array([ 0. , -0.3,  0.3,  0. ], dtype=float32)), NumberKeyframeTrack(name='.bones[2].rotation[z]', times=array([0. , 0.5, 1.5, 2. ], dtype=float32), values=array([ 0. , -0.3,  0.3,  0. ], dtype=float32)))), localRoot=SkinnedMesh(children=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), geometry=BufferGeometry(attributes={'position': <BufferAttribute shape=(96, 3), dtype=float32>, 'normal': <BufferAttribute shape=(96, 3), dtype=float32>, 'uv': <BufferAttribute shape=(96, 2), dtype=float32>, 'skinIndex': <BufferAttribute shape=(96, 4), dtype=float32>, 'skinWeight': <BufferAttribute shape=(96, 4), dtype=float32>}), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, normalMap=None, normalScale=(1.0, 1.0), side='DoubleSide', skinning=True, specularMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), skeleton=Skeleton(bones=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)))), up=(0.0, 1.0, 0.0)), mixer=AnimationMixer(rootObject=SkinnedMesh(children=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), geometry=BufferGeometry(attributes={'position': <BufferAttribute shape=(96, 3), dtype=float32>, 'normal': <BufferAttribute shape=(96, 3), dtype=float32>, 'uv': <BufferAttribute shape=(96, 2), dtype=float32>, 'skinIndex': <BufferAttribute shape=(96, 4), dtype=float32>, 'skinWeight': <BufferAttribute shape=(96, 4), dtype=float32>}), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, normalMap=None, normalScale=(1.0, 1.0), side='DoubleSide', skinning=True, specularMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), skeleton=Skeleton(bones=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)))), up=(0.0, 1.0, 0.0))))"
       ]
      },
      "metadata": {},
@@ -826,12 +787,16 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-skip"
+    ]
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c197a398de0f42d7a3d77c6a3e5014e0",
+       "model_id": "665aa037e4ab4a70be1e368c19c7a18b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -851,7 +816,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "AnimationAction(clip=AnimationClip(duration=2.0, tracks=(NumberKeyframeTrack(name='.bones[1].rotation[y]', times=array([ 0. ,  0.5,  1.5,  2. ], dtype=float32), values=array([ 0.        ,  0.69999999, -0.69999999,  0.        ], dtype=float32)), NumberKeyframeTrack(name='.bones[2].rotation[y]', times=array([ 0. ,  0.5,  1.5,  2. ], dtype=float32), values=array([ 0.        ,  0.69999999, -0.69999999,  0.        ], dtype=float32)))), localRoot=SkinnedMesh(children=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), geometry=Geometry(colors=['#ffffff']), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, normalMap=None, normalScale=(1.0, 1.0), side='DoubleSide', skinning=True, specularMap=None, type='MeshPhongMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), skeleton=Skeleton(bones=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)), Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)), Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)))), type='SkinnedMesh', up=(0.0, 1.0, 0.0)), mixer=AnimationMixer(rootObject=SkinnedMesh(children=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), geometry=Geometry(colors=['#ffffff']), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, normalMap=None, normalScale=(1.0, 1.0), side='DoubleSide', skinning=True, specularMap=None, type='MeshPhongMaterial'), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), skeleton=Skeleton(bones=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)), Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)), Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), type='Bone', up=(0.0, 1.0, 0.0)))), type='SkinnedMesh', up=(0.0, 1.0, 0.0))))"
+       "AnimationAction(clip=AnimationClip(duration=2.0, tracks=(NumberKeyframeTrack(name='.bones[1].rotation[y]', times=array([0. , 0.5, 1.5, 2. ], dtype=float32), values=array([ 0. ,  0.7, -0.7,  0. ], dtype=float32)), NumberKeyframeTrack(name='.bones[2].rotation[y]', times=array([0. , 0.5, 1.5, 2. ], dtype=float32), values=array([ 0. ,  0.7, -0.7,  0. ], dtype=float32)))), localRoot=SkinnedMesh(children=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), geometry=BufferGeometry(attributes={'position': <BufferAttribute shape=(96, 3), dtype=float32>, 'normal': <BufferAttribute shape=(96, 3), dtype=float32>, 'uv': <BufferAttribute shape=(96, 2), dtype=float32>, 'skinIndex': <BufferAttribute shape=(96, 4), dtype=float32>, 'skinWeight': <BufferAttribute shape=(96, 4), dtype=float32>}), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, normalMap=None, normalScale=(1.0, 1.0), side='DoubleSide', skinning=True, specularMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), skeleton=Skeleton(bones=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)))), up=(0.0, 1.0, 0.0)), mixer=AnimationMixer(rootObject=SkinnedMesh(children=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), geometry=BufferGeometry(attributes={'position': <BufferAttribute shape=(96, 3), dtype=float32>, 'normal': <BufferAttribute shape=(96, 3), dtype=float32>, 'uv': <BufferAttribute shape=(96, 2), dtype=float32>, 'skinIndex': <BufferAttribute shape=(96, 4), dtype=float32>, 'skinWeight': <BufferAttribute shape=(96, 4), dtype=float32>}), material=MeshPhongMaterial(alphaMap=None, aoMap=None, bumpMap=None, displacementMap=None, emissiveMap=None, envMap=None, lightMap=None, map=None, normalMap=None, normalScale=(1.0, 1.0), side='DoubleSide', skinning=True, specularMap=None), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), skeleton=Skeleton(bones=(Bone(children=(Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, -25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Bone(children=(Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)),), position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)), Bone(position=(0.0, 25.0, 0.0), quaternion=(0.0, 0.0, 0.0, 1.0), scale=(1.0, 1.0, 1.0), up=(0.0, 1.0, 0.0)))), up=(0.0, 1.0, 0.0))))"
       ]
      },
      "metadata": {},
@@ -886,921 +851,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.4"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "002b7b03200748d3b4d62a38c383f4e3": {
+     "0304ecb4ed1143bcad346b55dcbec86e": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationActionModel",
-      "state": {
-       "_model_module": "jupyter-threejs",
-       "_model_module_version": "0.4.0",
-       "_model_name": "AnimationActionModel",
-       "_view_module_version": "0.4.0",
-       "clip": "IPY_MODEL_d107df5fdf58423194c0fcec9bc916ab",
-       "layout": "IPY_MODEL_88fded967d154b94a5dc53d2691b1614",
-       "localRoot": "IPY_MODEL_96d31bd0f71b474b9950367ad61d4a9d",
-       "mixer": "IPY_MODEL_d280682347b74486be3601ae937c1883",
-       "repititions": "inf"
-      }
-     },
-     "02829a2eeab04a448f0ce62331791cf9": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "MeshLambertMaterialModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "color": "yellow",
-       "side": "BackSide",
-       "type": "MeshLambertMaterial"
-      }
-     },
-     "058e735c-2504-4214-aa55-1459cdf8f4d2": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "OrthographicCameraModel",
-      "state": {
-       "bottom": -5,
-       "far": 500,
-       "left": -5,
-       "near": 0.5,
-       "projectionMatrix": [
-        0.2,
-        0,
-        0,
-        0,
-        0,
-        0.2,
-        0,
-        0,
-        0,
-        0,
-        -0.004004004004004004,
-        0,
-        0,
-        0,
-        -1.002002002002002,
-        1
-       ],
-       "right": 5,
-       "top": 5,
-       "type": "OrthographicCamera"
-      }
-     },
-     "09db366bb99a42629d43eb33be5eb041": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "MeshPhongMaterialModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "side": "DoubleSide",
-       "skinning": true,
-       "type": "MeshPhongMaterial"
-      }
-     },
-     "16e2a1bfed974746b0d73bff9542af6d": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "GeometryModel",
-      "state": {
-       "_ref_geometry": "IPY_MODEL_4af1d948fce7444ead8d2497229bf283",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "17427107af1e42b98d19690a4b48647b": {
-      "buffers": [
-       {
-        "data": "AAAAAAAAAD8AAMA/AAAAQA==",
-        "encoding": "base64",
-        "path": [
-         "times",
-         "buffer"
-        ]
-       },
-       {
-        "data": "AAAAAJqZmb6amZk+AAAAAA==",
-        "encoding": "base64",
-        "path": [
-         "values",
-         "buffer"
-        ]
-       }
-      ],
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "NumberKeyframeTrackModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "name": ".bones[2].rotation[x]",
-       "times": {
-        "buffer": {},
-        "dtype": "float32",
-        "shape": [
-         4
-        ]
-       },
-       "values": {
-        "buffer": {},
-        "dtype": "float32",
-        "shape": [
-         4
-        ]
-       }
-      }
-     },
-     "178b9b11bc384f05a93a936ed6b09886": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationClipModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "duration": 1.5,
-       "tracks": [
-        "IPY_MODEL_3c747af7474a40408c980719d6e6607b"
-       ]
-      }
-     },
-     "1e03ce2d9ef64eccb1ccb4b2059822d6": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "OrbitControlsModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "controlling": "IPY_MODEL_96d31bd0f71b474b9950367ad61d4a9d",
-       "maxAzimuthAngle": "inf",
-       "maxDistance": "inf",
-       "maxZoom": "inf",
-       "minAzimuthAngle": "-inf"
-      }
-     },
-     "23bce2b9a9824dae8391240e9fbd185a": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationMixerModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "rootObject": "IPY_MODEL_41ca13be3d034bb78c5315b6cc84fadd"
-      }
-     },
-     "275c26b9f02d424c97e7d2bcfd241c81": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AmbientLightModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "intensity": 0.5,
-       "type": "AmbientLight"
-      }
-     },
-     "2ef858e830df4234bcd1b05305e8eaf9": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "30cec7cc2ef24f12a555c1d7504727d2": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "DirectionalLightModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "intensity": 0.6,
-       "matrixWorldNeedsUpdate": true,
-       "position": [
-        3,
-        5,
-        1
-       ],
-       "shadow": "IPY_MODEL_940459e3-ab89-4372-b343-1451541aeb6c",
-       "target": "IPY_MODEL_45f22feb-43e8-4dfd-9b9a-ef647667d0c4",
-       "type": "DirectionalLight"
-      }
-     },
-     "30fd684c-33b5-42bb-8fb0-b2735580d4ca": {
-      "buffers": [
-       {
-        "data": "AAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAwsVHvr4Uez8AAAAAFe9Dvr4Uez8M5Rs905A4vr4Uez815pg90Romvr4Uez+t+d09r0INvr4Uez+vQg0+rfndvb4Uez/RGiY+NeaYvb4Uez/TkDg+DOUbvb4Uez8V70M+n1xco74Uez/CxUc+DOUbPb4Uez8V70M+NeaYPb4Uez/TkDg+rfndPb4Uez/RGiY+r0INPr4Uez+vQg0+0RomPr4Uez+t+d0905A4Pr4Uez815pg9Fe9DPr4Uez8M5Rs9wsVHPr4Uez+fXNwjFe9DPr4Uez8M5Ru905A4Pr4Uez815pi90RomPr4Uez+t+d29r0INPr4Uez+vQg2+rfndPb4Uez/RGia+NeaYPb4Uez/TkDi+DOUbPb4Uez8V70O+d0UlJL4Uez/CxUe+DOUbvb4Uez8V70O+NeaYvb4Uez/TkDi+rfndvb4Uez/RGia+r0INvr4Uez+vQg2+0Romvr4Uez+t+d2905A4vr4Uez815pi9Fe9Dvr4Uez8M5Ru9wsVHvr4Uez+fXFykFe/Dvl6DbD8AAAAASivAvl6DbD815pg98wS1vl6DbD8a9hU+wemivl6DbD/JtVk+1IuKvl6DbD/Ui4o+ybVZvl6DbD/B6aI+GvYVvl6DbD/zBLU+NeaYvV6DbD9KK8A+qyDYo16DbD8V78M+NeaYPV6DbD9KK8A+GvYVPl6DbD/zBLU+ybVZPl6DbD/B6aI+1IuKPl6DbD/Ui4o+wemiPl6DbD/JtVk+8wS1Pl6DbD8a9hU+SivAPl6DbD815pg9Fe/DPl6DbD+rIFgkSivAPl6DbD815pi98wS1Pl6DbD8a9hW+wemiPl6DbD/JtVm+1IuKPl6DbD/Ui4q+ybVZPl6DbD/B6aK+GvYVPl6DbD/zBLW+NeaYPV6DbD9KK8C+gBiiJF6DbD8V78O+NeaYvV6DbD9KK8C+GvYVvl6DbD/zBLW+ybVZvl6DbD/B6aK+1IuKvl6DbD/Ui4q+wemivl6DbD/JtVm+8wS1vl6DbD8a9hW+SivAvl6DbD815pi9Fe/Dvl6DbD+rINik2jkOvzHbVD8AAAAAP34LvzHbVD+t+d09UWYDvzHbVD/JtVk+XoPsvjHbVD91CJ4+TiPJvjHbVD9OI8k+dQievjHbVD9eg+w+ybVZvjHbVD9RZgM/rfndvTHbVD8/fgs/Y+IcpDHbVD/aOQ4/rfndPTHbVD8/fgs/ybVZPjHbVD9RZgM/dQiePjHbVD9eg+w+TiPJPjHbVD9OI8k+XoPsPjHbVD91CJ4+UWYDPzHbVD/JtVk+P34LPzHbVD+t+d092jkOPzHbVD9j4pwkP34LPzHbVD+t+d29UWYDPzHbVD/JtVm+XoPsPjHbVD91CJ6+TiPJPjHbVD9OI8m+dQiePjHbVD9eg+y+ybVZPjHbVD9RZgO/rfndPTHbVD8/fgu/lVPrJDHbVD/aOQ6/rfndvTHbVD8/fgu/ybVZvjHbVD9RZgO/dQievjHbVD9eg+y+TiPJvjHbVD9OI8m+XoPsvjHbVD91CJ6+UWYDvzHbVD/JtVm+P34LvzHbVD+t+d292jkOvzHbVD9j4hyl8wQ1v/MENT8AAAAAhooxv/MENT+vQg0+dT0nv/MENT/Ui4o+F4MWv/MENT9OI8k+AAAAv/MENT8AAAA/TiPJvvMENT8XgxY/1IuKvvMENT91PSc/r0INvvMENT+GijE/Bq1HpPMENT/zBDU/r0INPvMENT+GijE/1IuKPvMENT91PSc/TiPJPvMENT8XgxY/AAAAP/MENT8AAAA/F4MWP/MENT9OI8k+dT0nP/MENT/Ui4o+hooxP/MENT+vQg0+8wQ1P/MENT8GrcckhooxP/MENT+vQg2+dT0nP/MENT/Ui4q+F4MWP/MENT9OI8m+AAAAP/MENT8AAAC/TiPJPvMENT8Xgxa/1IuKPvMENT91PSe/r0INPvMENT+GijG/xMEVJfMENT/zBDW/r0INvvMENT+GijG/1IuKvvMENT91PSe/TiPJvvMENT8Xgxa/AAAAv/MENT8AAAC/F4MWv/MENT9OI8m+dT0nv/MENT/Ui4q+hooxv/MENT+vQg2+8wQ1v/MENT8GrUelMdtUv9o5Dj8AAAAAKcRQv9o5Dj/RGiY+TKdEv9o5Dj/B6aI+xfswv9o5Dj9eg+w+F4MWv9o5Dj8XgxY/XoPsvto5Dj/F+zA/wemivto5Dj9Mp0Q/0Romvto5Dj8pxFA/Q8tqpNo5Dj8x21Q/0RomPto5Dj8pxFA/wemiPto5Dj9Mp0Q/XoPsPto5Dj/F+zA/F4MWP9o5Dj8XgxY/xfswP9o5Dj9eg+w+TKdEP9o5Dj/B6aI+KcRQP9o5Dj/RGiY+MdtUP9o5Dj9Dy+okKcRQP9o5Dj/RGia+TKdEP9o5Dj/B6aK+xfswP9o5Dj9eg+y+F4MWP9o5Dj8Xgxa/XoPsPto5Dj/F+zC/wemiPto5Dj9Mp0S/0RomPto5Dj8pxFC/chgwJdo5Dj8x21S/0Romvto5Dj8pxFC/wemivto5Dj9Mp0S/XoPsvto5Dj/F+zC/F4MWv9o5Dj8Xgxa/xfswv9o5Dj9eg+y+TKdEv9o5Dj/B6aK+KcRQv9o5Dj/RGia+MdtUv9o5Dj9Dy2qlXoNsvxXvwz4AAAAA+PdnvxXvwz7TkDg+eoJavxXvwz7zBLU+TKdEvxXvwz5RZgM/dT0nvxXvwz51PSc/UWYDvxXvwz5Mp0Q/8wS1vhXvwz56glo/05A4vhXvwz7492c/znGCpBXvwz5eg2w/05A4PhXvwz7492c/8wS1PhXvwz56glo/UWYDPxXvwz5Mp0Q/dT0nPxXvwz51PSc/TKdEPxXvwz5RZgM/eoJaPxXvwz7zBLU++PdnPxXvwz7TkDg+XoNsPxXvwz7OcQIl+PdnPxXvwz7TkDi+eoJaPxXvwz7zBLW+TKdEPxXvwz5RZgO/dT0nPxXvwz51PSe/UWYDPxXvwz5Mp0S/8wS1PhXvwz56glq/05A4PhXvwz7492e/tapDJRXvwz5eg2y/05A4vhXvwz7492e/8wS1vhXvwz56glq/UWYDvxXvwz5Mp0S/dT0nvxXvwz51PSe/TKdEvxXvwz5RZgO/eoJavxXvwz7zBLW++PdnvxXvwz7TkDi+XoNsvxXvwz7OcYKlvhR7v8LFRz4AAAAAr0F2v8LFRz4V70M++Pdnv8LFRz5KK8A+KcRQv8LFRz4/fgs/hooxv8LFRz6GijE/P34Lv8LFRz4pxFA/SivAvsLFRz7492c/Fe9DvsLFRz6vQXY/rXqKpMLFRz6+FHs/Fe9DPsLFRz6vQXY/SivAPsLFRz7492c/P34LP8LFRz4pxFA/hooxP8LFRz6GijE/KcRQP8LFRz4/fgs/+PdnP8LFRz5KK8A+r0F2P8LFRz4V70M+vhR7P8LFRz6tegolr0F2P8LFRz4V70O++PdnP8LFRz5KK8C+KcRQP8LFRz4/fgu/hooxP8LFRz6GijG/P34LP8LFRz4pxFC/SivAPsLFRz7492e/Fe9DPsLFRz6vQXa/A7hPJcLFRz6+FHu/Fe9DvsLFRz6vQXa/SivAvsLFRz7492e/P34Lv8LFRz4pxFC/hooxv8LFRz6GijG/KcRQv8LFRz4/fgu/+Pdnv8LFRz5KK8C+r0F2v8LFRz4V70O+vhR7v8LFRz6teoqlAACAvzIxjSQAAAAAvhR7vzIxjSTCxUc+XoNsvzIxjSQV78M+MdtUvzIxjSTaOQ4/8wQ1vzIxjSTzBDU/2jkOvzIxjSQx21Q/Fe/DvjIxjSReg2w/wsVHvjIxjSS+FHs/MjGNpDIxjSQAAIA/wsVHPjIxjSS+FHs/Fe/DPjIxjSReg2w/2jkOPzIxjSQx21Q/8wQ1PzIxjSTzBDU/MdtUPzIxjSTaOQ4/XoNsPzIxjSQV78M+vhR7PzIxjSTCxUc+AACAPzIxjSQyMQ0lvhR7PzIxjSTCxUe+XoNsPzIxjSQV78O+MdtUPzIxjSTaOQ6/8wQ1PzIxjSTzBDW/2jkOPzIxjSQx21S/Fe/DPjIxjSReg2y/wsVHPjIxjSS+FHu/yslTJTIxjSQAAIC/wsVHvjIxjSS+FHu/Fe/DvjIxjSReg2y/2jkOvzIxjSQx21S/8wQ1vzIxjSTzBDW/MdtUvzIxjSTaOQ6/XoNsvzIxjSQV78O+vhR7vzIxjSTCxUe+AACAvzIxjSQyMY2lvhR7v8LFR74AAAAAr0F2v8LFR74V70M++Pdnv8LFR75KK8A+KcRQv8LFR74/fgs/hooxv8LFR76GijE/P34Lv8LFR74pxFA/SivAvsLFR77492c/Fe9DvsLFR76vQXY/rXqKpMLFR76+FHs/Fe9DPsLFR76vQXY/SivAPsLFR77492c/P34LP8LFR74pxFA/hooxP8LFR76GijE/KcRQP8LFR74/fgs/+PdnP8LFR75KK8A+r0F2P8LFR74V70M+vhR7P8LFR76tegolr0F2P8LFR74V70O++PdnP8LFR75KK8C+KcRQP8LFR74/fgu/hooxP8LFR76GijG/P34LP8LFR74pxFC/SivAPsLFR77492e/Fe9DPsLFR76vQXa/A7hPJcLFR76+FHu/Fe9DvsLFR76vQXa/SivAvsLFR77492e/P34Lv8LFR74pxFC/hooxv8LFR76GijG/KcRQv8LFR74/fgu/+Pdnv8LFR75KK8C+r0F2v8LFR74V70O+vhR7v8LFR76teoqlXoNsvxXvw74AAAAA+PdnvxXvw77TkDg+eoJavxXvw77zBLU+TKdEvxXvw75RZgM/dT0nvxXvw751PSc/UWYDvxXvw75Mp0Q/8wS1vhXvw756glo/05A4vhXvw77492c/znGCpBXvw75eg2w/05A4PhXvw77492c/8wS1PhXvw756glo/UWYDPxXvw75Mp0Q/dT0nPxXvw751PSc/TKdEPxXvw75RZgM/eoJaPxXvw77zBLU++PdnPxXvw77TkDg+XoNsPxXvw77OcQIl+PdnPxXvw77TkDi+eoJaPxXvw77zBLW+TKdEPxXvw75RZgO/dT0nPxXvw751PSe/UWYDPxXvw75Mp0S/8wS1PhXvw756glq/05A4PhXvw77492e/tapDJRXvw75eg2y/05A4vhXvw77492e/8wS1vhXvw756glq/UWYDvxXvw75Mp0S/dT0nvxXvw751PSe/TKdEvxXvw75RZgO/eoJavxXvw77zBLW++PdnvxXvw77TkDi+XoNsvxXvw77OcYKlMdtUv9o5Dr8AAAAAKcRQv9o5Dr/RGiY+TKdEv9o5Dr/B6aI+xfswv9o5Dr9eg+w+F4MWv9o5Dr8XgxY/XoPsvto5Dr/F+zA/wemivto5Dr9Mp0Q/0Romvto5Dr8pxFA/Q8tqpNo5Dr8x21Q/0RomPto5Dr8pxFA/wemiPto5Dr9Mp0Q/XoPsPto5Dr/F+zA/F4MWP9o5Dr8XgxY/xfswP9o5Dr9eg+w+TKdEP9o5Dr/B6aI+KcRQP9o5Dr/RGiY+MdtUP9o5Dr9Dy+okKcRQP9o5Dr/RGia+TKdEP9o5Dr/B6aK+xfswP9o5Dr9eg+y+F4MWP9o5Dr8Xgxa/XoPsPto5Dr/F+zC/wemiPto5Dr9Mp0S/0RomPto5Dr8pxFC/chgwJdo5Dr8x21S/0Romvto5Dr8pxFC/wemivto5Dr9Mp0S/XoPsvto5Dr/F+zC/F4MWv9o5Dr8Xgxa/xfswv9o5Dr9eg+y+TKdEv9o5Dr/B6aK+KcRQv9o5Dr/RGia+MdtUv9o5Dr9Dy2ql8wQ1v/MENb8AAAAAhooxv/MENb+vQg0+dT0nv/MENb/Ui4o+F4MWv/MENb9OI8k+AAAAv/MENb8AAAA/TiPJvvMENb8XgxY/1IuKvvMENb91PSc/r0INvvMENb+GijE/Bq1HpPMENb/zBDU/r0INPvMENb+GijE/1IuKPvMENb91PSc/TiPJPvMENb8XgxY/AAAAP/MENb8AAAA/F4MWP/MENb9OI8k+dT0nP/MENb/Ui4o+hooxP/MENb+vQg0+8wQ1P/MENb8GrcckhooxP/MENb+vQg2+dT0nP/MENb/Ui4q+F4MWP/MENb9OI8m+AAAAP/MENb8AAAC/TiPJPvMENb8Xgxa/1IuKPvMENb91PSe/r0INPvMENb+GijG/xMEVJfMENb/zBDW/r0INvvMENb+GijG/1IuKvvMENb91PSe/TiPJvvMENb8Xgxa/AAAAv/MENb8AAAC/F4MWv/MENb9OI8m+dT0nv/MENb/Ui4q+hooxv/MENb+vQg2+8wQ1v/MENb8GrUel2jkOvzHbVL8AAAAAP34LvzHbVL+t+d09UWYDvzHbVL/JtVk+XoPsvjHbVL91CJ4+TiPJvjHbVL9OI8k+dQievjHbVL9eg+w+ybVZvjHbVL9RZgM/rfndvTHbVL8/fgs/Y+IcpDHbVL/aOQ4/rfndPTHbVL8/fgs/ybVZPjHbVL9RZgM/dQiePjHbVL9eg+w+TiPJPjHbVL9OI8k+XoPsPjHbVL91CJ4+UWYDPzHbVL/JtVk+P34LPzHbVL+t+d092jkOPzHbVL9j4pwkP34LPzHbVL+t+d29UWYDPzHbVL/JtVm+XoPsPjHbVL91CJ6+TiPJPjHbVL9OI8m+dQiePjHbVL9eg+y+ybVZPjHbVL9RZgO/rfndPTHbVL8/fgu/lVPrJDHbVL/aOQ6/rfndvTHbVL8/fgu/ybVZvjHbVL9RZgO/dQievjHbVL9eg+y+TiPJvjHbVL9OI8m+XoPsvjHbVL91CJ6+UWYDvzHbVL/JtVm+P34LvzHbVL+t+d292jkOvzHbVL9j4hylFe/Dvl6DbL8AAAAASivAvl6DbL815pg98wS1vl6DbL8a9hU+wemivl6DbL/JtVk+1IuKvl6DbL/Ui4o+ybVZvl6DbL/B6aI+GvYVvl6DbL/zBLU+NeaYvV6DbL9KK8A+qyDYo16DbL8V78M+NeaYPV6DbL9KK8A+GvYVPl6DbL/zBLU+ybVZPl6DbL/B6aI+1IuKPl6DbL/Ui4o+wemiPl6DbL/JtVk+8wS1Pl6DbL8a9hU+SivAPl6DbL815pg9Fe/DPl6DbL+rIFgkSivAPl6DbL815pi98wS1Pl6DbL8a9hW+wemiPl6DbL/JtVm+1IuKPl6DbL/Ui4q+ybVZPl6DbL/B6aK+GvYVPl6DbL/zBLW+NeaYPV6DbL9KK8C+gBiiJF6DbL8V78O+NeaYvV6DbL9KK8C+GvYVvl6DbL/zBLW+ybVZvl6DbL/B6aK+1IuKvl6DbL/Ui4q+wemivl6DbL/JtVm+8wS1vl6DbL8a9hW+SivAvl6DbL815pi9Fe/Dvl6DbL+rINikwsVHvr4Ue78AAAAAFe9Dvr4Ue78M5Rs905A4vr4Ue7815pg90Romvr4Ue7+t+d09r0INvr4Ue7+vQg0+rfndvb4Ue7/RGiY+NeaYvb4Ue7/TkDg+DOUbvb4Ue78V70M+n1xco74Ue7/CxUc+DOUbPb4Ue78V70M+NeaYPb4Ue7/TkDg+rfndPb4Ue7/RGiY+r0INPr4Ue7+vQg0+0RomPr4Ue7+t+d0905A4Pr4Ue7815pg9Fe9DPr4Ue78M5Rs9wsVHPr4Ue7+fXNwjFe9DPr4Ue78M5Ru905A4Pr4Ue7815pi90RomPr4Ue7+t+d29r0INPr4Ue7+vQg2+rfndPb4Ue7/RGia+NeaYPb4Ue7/TkDi+DOUbPb4Ue78V70O+d0UlJL4Ue7/CxUe+DOUbvb4Ue78V70O+NeaYvb4Ue7/TkDi+rfndvb4Ue7/RGia+r0INvr4Ue7+vQg2+0Romvr4Ue7+t+d2905A4vr4Ue7815pi9Fe9Dvr4Ue78M5Ru9wsVHvr4Ue7+fXFykMjENpQAAgL8AAAAArXoKpQAAgL+fXNwjznECpQAAgL+rIFgkQ8vqpAAAgL9j4pwkBq3HpAAAgL8GrcckY+KcpAAAgL9Dy+okqyBYpAAAgL/OcQIln1zcowAAgL+tegoldL4bigAAgL8yMQ0ln1zcIwAAgL+tegolqyBYJAAAgL/OcQIlY+KcJAAAgL9Dy+okBq3HJAAAgL8GrcckQ8vqJAAAgL9j4pwkznECJQAAgL+rIFgkrXoKJQAAgL+fXNwjMjENJQAAgL90vpsKrXoKJQAAgL+fXNyjznECJQAAgL+rIFikQ8vqJAAAgL9j4pykBq3HJAAAgL8GrcekY+KcJAAAgL9Dy+qkqyBYJAAAgL/OcQKln1zcIwAAgL+tegqlrp3pCgAAgL8yMQ2ln1zcowAAgL+tegqlqyBYpAAAgL/OcQKlY+KcpAAAgL9Dy+qkBq3HpAAAgL8GrcekQ8vqpAAAgL9j4pykznECpQAAgL+rIFikrXoKpQAAgL+fXNyjMjENpQAAgL90vhuL",
-        "encoding": "base64",
-        "path": [
-         "array",
-         "buffer"
-        ]
-       }
-      ],
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "BufferAttributeModel",
-      "state": {
-       "array": {
-        "buffer": {},
-        "dtype": "float32",
-        "shape": [
-         561,
-         3
-        ]
-       },
-       "normalized": false,
-       "version": 0
-      }
-     },
-     "33ab0f258f3946c79d32e5979ec18072": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "341dd569-5c9f-4bb7-b459-3df244122885": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "OrthographicCameraModel",
-      "state": {
-       "bottom": -5,
-       "far": 500,
-       "left": -5,
-       "near": 0.5,
-       "projectionMatrix": [
-        0.2,
-        0,
-        0,
-        0,
-        0,
-        0.2,
-        0,
-        0,
-        0,
-        0,
-        -0.004004004004004004,
-        0,
-        0,
-        0,
-        -1.002002002002002,
-        1
-       ],
-       "right": 5,
-       "top": 5,
-       "type": "OrthographicCamera"
-      }
-     },
-     "377cf03634924f13847c7c218298b7c9": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "3c747af7474a40408c980719d6e6607b": {
-      "buffers": [
-       {
-        "data": "AAAAAAEAAAA=",
-        "encoding": "base64",
-        "path": [
-         "times",
-         "buffer"
-        ]
-       },
-       {
-        "data": "AQAAAAAAAAAAAAAAAAAAAAAAAAABAAAA",
-        "encoding": "base64",
-        "path": [
-         "values",
-         "buffer"
-        ]
-       }
-      ],
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "ColorKeyframeTrackModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "name": ".material.color",
-       "times": {
-        "buffer": {},
-        "dtype": "int32",
-        "shape": [
-         2
-        ]
-       },
-       "values": {
-        "buffer": {},
-        "dtype": "int32",
-        "shape": [
-         6
-        ]
-       }
-      }
-     },
-     "3c92703508034441bf28382412ac2fe5": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "3e0d84be-3813-45f9-a6ce-e1cd1346287d": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "OrthographicCameraModel",
-      "state": {
-       "bottom": -5,
-       "far": 500,
-       "left": -5,
-       "near": 0.5,
-       "projectionMatrix": [
-        0.2,
-        0,
-        0,
-        0,
-        0,
-        0.2,
-        0,
-        0,
-        0,
-        0,
-        -0.004004004004004004,
-        0,
-        0,
-        0,
-        -1.002002002002002,
-        1
-       ],
-       "right": 5,
-       "top": 5,
-       "type": "OrthographicCamera"
-      }
-     },
-     "40bc08d47f60411186632f40b42248b5": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "MeshModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "geometry": "IPY_MODEL_4abd8adb5df6411886e59d5d00e495ea",
-       "material": "IPY_MODEL_4386a4b13cea41fcb3278cd98650b722",
-       "morphTargetInfluences": [],
-       "type": "Mesh"
-      }
-     },
-     "4100bf58c9c7450093a880767a813070": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "MeshModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "geometry": "IPY_MODEL_c041c44e665947fa9ed8a427a5a5abb8",
-       "material": "IPY_MODEL_52ccaf76ffc546fcba84fcceeaf68a02",
-       "morphTargetInfluences": [],
-       "type": "Mesh"
-      }
-     },
-     "41045c4aa130473191016ccbf764a051": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "41ca13be3d034bb78c5315b6cc84fadd": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "GroupModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "children": [
-        "IPY_MODEL_4100bf58c9c7450093a880767a813070",
-        "IPY_MODEL_50801120cfdb4f4f91599c0c9aeef939"
-       ],
-       "type": "Group"
-      }
-     },
-     "421de1b8aa2d425e8315141888f2bee8": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "RendererModel",
-      "state": {
-       "_height": 400,
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "_width": 600,
-       "camera": "IPY_MODEL_96d31bd0f71b474b9950367ad61d4a9d",
-       "controls": [
-        "IPY_MODEL_1e03ce2d9ef64eccb1ccb4b2059822d6"
-       ],
-       "layout": "IPY_MODEL_33ab0f258f3946c79d32e5979ec18072",
-       "scene": "IPY_MODEL_ef32ce4223e44d84b93e045f75be7483",
-       "shadowMap": "IPY_MODEL_c34d72a5bef2409d84d8ac4b4edfbbff"
-      }
-     },
-     "4386a4b13cea41fcb3278cd98650b722": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "MeshStandardMaterialModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "color": "red",
-       "type": "MeshStandardMaterial"
-      }
-     },
-     "448c47c1-4b22-444a-956f-3d21c3cfd450": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "Object3DModel",
-      "state": {
-       "type": "Object3D"
-      }
-     },
-     "45bac4cd84f243489f3fce05c49fd8eb": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationClipModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "duration": 2,
-       "tracks": [
-        "IPY_MODEL_6a36d1d9a40f4ec4b5b79b9fd2c09089"
-       ]
-      }
-     },
-     "45f22feb-43e8-4dfd-9b9a-ef647667d0c4": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "Object3DModel",
-      "state": {
-       "type": "Object3D"
-      }
-     },
-     "46d49ebf-edb1-4066-95a6-3b798f34dc82": {
-      "buffers": [
-       {
-        "data": "AAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAwsVHvr4Uez8AAAAAFe9Dvr4Uez8M5Rs905A4vr4Uez815pg90Romvr4Uez+t+d09r0INvr4Uez+vQg0+rfndvb4Uez/RGiY+NeaYvb4Uez/TkDg+DOUbvb4Uez8V70M+n1xco74Uez/CxUc+DOUbPb4Uez8V70M+NeaYPb4Uez/TkDg+rfndPb4Uez/RGiY+r0INPr4Uez+vQg0+0RomPr4Uez+t+d0905A4Pr4Uez815pg9Fe9DPr4Uez8M5Rs9wsVHPr4Uez+fXNwjFe9DPr4Uez8M5Ru905A4Pr4Uez815pi90RomPr4Uez+t+d29r0INPr4Uez+vQg2+rfndPb4Uez/RGia+NeaYPb4Uez/TkDi+DOUbPb4Uez8V70O+d0UlJL4Uez/CxUe+DOUbvb4Uez8V70O+NeaYvb4Uez/TkDi+rfndvb4Uez/RGia+r0INvr4Uez+vQg2+0Romvr4Uez+t+d2905A4vr4Uez815pi9Fe9Dvr4Uez8M5Ru9wsVHvr4Uez+fXFykFe/Dvl6DbD8AAAAASivAvl6DbD815pg98wS1vl6DbD8a9hU+wemivl6DbD/JtVk+1IuKvl6DbD/Ui4o+ybVZvl6DbD/B6aI+GvYVvl6DbD/zBLU+NeaYvV6DbD9KK8A+qyDYo16DbD8V78M+NeaYPV6DbD9KK8A+GvYVPl6DbD/zBLU+ybVZPl6DbD/B6aI+1IuKPl6DbD/Ui4o+wemiPl6DbD/JtVk+8wS1Pl6DbD8a9hU+SivAPl6DbD815pg9Fe/DPl6DbD+rIFgkSivAPl6DbD815pi98wS1Pl6DbD8a9hW+wemiPl6DbD/JtVm+1IuKPl6DbD/Ui4q+ybVZPl6DbD/B6aK+GvYVPl6DbD/zBLW+NeaYPV6DbD9KK8C+gBiiJF6DbD8V78O+NeaYvV6DbD9KK8C+GvYVvl6DbD/zBLW+ybVZvl6DbD/B6aK+1IuKvl6DbD/Ui4q+wemivl6DbD/JtVm+8wS1vl6DbD8a9hW+SivAvl6DbD815pi9Fe/Dvl6DbD+rINik2jkOvzHbVD8AAAAAP34LvzHbVD+t+d09UWYDvzHbVD/JtVk+XoPsvjHbVD91CJ4+TiPJvjHbVD9OI8k+dQievjHbVD9eg+w+ybVZvjHbVD9RZgM/rfndvTHbVD8/fgs/Y+IcpDHbVD/aOQ4/rfndPTHbVD8/fgs/ybVZPjHbVD9RZgM/dQiePjHbVD9eg+w+TiPJPjHbVD9OI8k+XoPsPjHbVD91CJ4+UWYDPzHbVD/JtVk+P34LPzHbVD+t+d092jkOPzHbVD9j4pwkP34LPzHbVD+t+d29UWYDPzHbVD/JtVm+XoPsPjHbVD91CJ6+TiPJPjHbVD9OI8m+dQiePjHbVD9eg+y+ybVZPjHbVD9RZgO/rfndPTHbVD8/fgu/lVPrJDHbVD/aOQ6/rfndvTHbVD8/fgu/ybVZvjHbVD9RZgO/dQievjHbVD9eg+y+TiPJvjHbVD9OI8m+XoPsvjHbVD91CJ6+UWYDvzHbVD/JtVm+P34LvzHbVD+t+d292jkOvzHbVD9j4hyl8wQ1v/MENT8AAAAAhooxv/MENT+vQg0+dT0nv/MENT/Ui4o+F4MWv/MENT9OI8k+AAAAv/MENT8AAAA/TiPJvvMENT8XgxY/1IuKvvMENT91PSc/r0INvvMENT+GijE/Bq1HpPMENT/zBDU/r0INPvMENT+GijE/1IuKPvMENT91PSc/TiPJPvMENT8XgxY/AAAAP/MENT8AAAA/F4MWP/MENT9OI8k+dT0nP/MENT/Ui4o+hooxP/MENT+vQg0+8wQ1P/MENT8GrcckhooxP/MENT+vQg2+dT0nP/MENT/Ui4q+F4MWP/MENT9OI8m+AAAAP/MENT8AAAC/TiPJPvMENT8Xgxa/1IuKPvMENT91PSe/r0INPvMENT+GijG/xMEVJfMENT/zBDW/r0INvvMENT+GijG/1IuKvvMENT91PSe/TiPJvvMENT8Xgxa/AAAAv/MENT8AAAC/F4MWv/MENT9OI8m+dT0nv/MENT/Ui4q+hooxv/MENT+vQg2+8wQ1v/MENT8GrUelMdtUv9o5Dj8AAAAAKcRQv9o5Dj/RGiY+TKdEv9o5Dj/B6aI+xfswv9o5Dj9eg+w+F4MWv9o5Dj8XgxY/XoPsvto5Dj/F+zA/wemivto5Dj9Mp0Q/0Romvto5Dj8pxFA/Q8tqpNo5Dj8x21Q/0RomPto5Dj8pxFA/wemiPto5Dj9Mp0Q/XoPsPto5Dj/F+zA/F4MWP9o5Dj8XgxY/xfswP9o5Dj9eg+w+TKdEP9o5Dj/B6aI+KcRQP9o5Dj/RGiY+MdtUP9o5Dj9Dy+okKcRQP9o5Dj/RGia+TKdEP9o5Dj/B6aK+xfswP9o5Dj9eg+y+F4MWP9o5Dj8Xgxa/XoPsPto5Dj/F+zC/wemiPto5Dj9Mp0S/0RomPto5Dj8pxFC/chgwJdo5Dj8x21S/0Romvto5Dj8pxFC/wemivto5Dj9Mp0S/XoPsvto5Dj/F+zC/F4MWv9o5Dj8Xgxa/xfswv9o5Dj9eg+y+TKdEv9o5Dj/B6aK+KcRQv9o5Dj/RGia+MdtUv9o5Dj9Dy2qlXoNsvxXvwz4AAAAA+PdnvxXvwz7TkDg+eoJavxXvwz7zBLU+TKdEvxXvwz5RZgM/dT0nvxXvwz51PSc/UWYDvxXvwz5Mp0Q/8wS1vhXvwz56glo/05A4vhXvwz7492c/znGCpBXvwz5eg2w/05A4PhXvwz7492c/8wS1PhXvwz56glo/UWYDPxXvwz5Mp0Q/dT0nPxXvwz51PSc/TKdEPxXvwz5RZgM/eoJaPxXvwz7zBLU++PdnPxXvwz7TkDg+XoNsPxXvwz7OcQIl+PdnPxXvwz7TkDi+eoJaPxXvwz7zBLW+TKdEPxXvwz5RZgO/dT0nPxXvwz51PSe/UWYDPxXvwz5Mp0S/8wS1PhXvwz56glq/05A4PhXvwz7492e/tapDJRXvwz5eg2y/05A4vhXvwz7492e/8wS1vhXvwz56glq/UWYDvxXvwz5Mp0S/dT0nvxXvwz51PSe/TKdEvxXvwz5RZgO/eoJavxXvwz7zBLW++PdnvxXvwz7TkDi+XoNsvxXvwz7OcYKlvhR7v8LFRz4AAAAAr0F2v8LFRz4V70M++Pdnv8LFRz5KK8A+KcRQv8LFRz4/fgs/hooxv8LFRz6GijE/P34Lv8LFRz4pxFA/SivAvsLFRz7492c/Fe9DvsLFRz6vQXY/rXqKpMLFRz6+FHs/Fe9DPsLFRz6vQXY/SivAPsLFRz7492c/P34LP8LFRz4pxFA/hooxP8LFRz6GijE/KcRQP8LFRz4/fgs/+PdnP8LFRz5KK8A+r0F2P8LFRz4V70M+vhR7P8LFRz6tegolr0F2P8LFRz4V70O++PdnP8LFRz5KK8C+KcRQP8LFRz4/fgu/hooxP8LFRz6GijG/P34LP8LFRz4pxFC/SivAPsLFRz7492e/Fe9DPsLFRz6vQXa/A7hPJcLFRz6+FHu/Fe9DvsLFRz6vQXa/SivAvsLFRz7492e/P34Lv8LFRz4pxFC/hooxv8LFRz6GijG/KcRQv8LFRz4/fgu/+Pdnv8LFRz5KK8C+r0F2v8LFRz4V70O+vhR7v8LFRz6teoqlAACAvzIxjSQAAAAAvhR7vzIxjSTCxUc+XoNsvzIxjSQV78M+MdtUvzIxjSTaOQ4/8wQ1vzIxjSTzBDU/2jkOvzIxjSQx21Q/Fe/DvjIxjSReg2w/wsVHvjIxjSS+FHs/MjGNpDIxjSQAAIA/wsVHPjIxjSS+FHs/Fe/DPjIxjSReg2w/2jkOPzIxjSQx21Q/8wQ1PzIxjSTzBDU/MdtUPzIxjSTaOQ4/XoNsPzIxjSQV78M+vhR7PzIxjSTCxUc+AACAPzIxjSQyMQ0lvhR7PzIxjSTCxUe+XoNsPzIxjSQV78O+MdtUPzIxjSTaOQ6/8wQ1PzIxjSTzBDW/2jkOPzIxjSQx21S/Fe/DPjIxjSReg2y/wsVHPjIxjSS+FHu/yslTJTIxjSQAAIC/wsVHvjIxjSS+FHu/Fe/DvjIxjSReg2y/2jkOvzIxjSQx21S/8wQ1vzIxjSTzBDW/MdtUvzIxjSTaOQ6/XoNsvzIxjSQV78O+vhR7vzIxjSTCxUe+AACAvzIxjSQyMY2lvhR7v8LFR74AAAAAr0F2v8LFR74V70M++Pdnv8LFR75KK8A+KcRQv8LFR74/fgs/hooxv8LFR76GijE/P34Lv8LFR74pxFA/SivAvsLFR77492c/Fe9DvsLFR76vQXY/rXqKpMLFR76+FHs/Fe9DPsLFR76vQXY/SivAPsLFR77492c/P34LP8LFR74pxFA/hooxP8LFR76GijE/KcRQP8LFR74/fgs/+PdnP8LFR75KK8A+r0F2P8LFR74V70M+vhR7P8LFR76tegolr0F2P8LFR74V70O++PdnP8LFR75KK8C+KcRQP8LFR74/fgu/hooxP8LFR76GijG/P34LP8LFR74pxFC/SivAPsLFR77492e/Fe9DPsLFR76vQXa/A7hPJcLFR76+FHu/Fe9DvsLFR76vQXa/SivAvsLFR77492e/P34Lv8LFR74pxFC/hooxv8LFR76GijG/KcRQv8LFR74/fgu/+Pdnv8LFR75KK8C+r0F2v8LFR74V70O+vhR7v8LFR76teoqlXoNsvxXvw74AAAAA+PdnvxXvw77TkDg+eoJavxXvw77zBLU+TKdEvxXvw75RZgM/dT0nvxXvw751PSc/UWYDvxXvw75Mp0Q/8wS1vhXvw756glo/05A4vhXvw77492c/znGCpBXvw75eg2w/05A4PhXvw77492c/8wS1PhXvw756glo/UWYDPxXvw75Mp0Q/dT0nPxXvw751PSc/TKdEPxXvw75RZgM/eoJaPxXvw77zBLU++PdnPxXvw77TkDg+XoNsPxXvw77OcQIl+PdnPxXvw77TkDi+eoJaPxXvw77zBLW+TKdEPxXvw75RZgO/dT0nPxXvw751PSe/UWYDPxXvw75Mp0S/8wS1PhXvw756glq/05A4PhXvw77492e/tapDJRXvw75eg2y/05A4vhXvw77492e/8wS1vhXvw756glq/UWYDvxXvw75Mp0S/dT0nvxXvw751PSe/TKdEvxXvw75RZgO/eoJavxXvw77zBLW++PdnvxXvw77TkDi+XoNsvxXvw77OcYKlMdtUv9o5Dr8AAAAAKcRQv9o5Dr/RGiY+TKdEv9o5Dr/B6aI+xfswv9o5Dr9eg+w+F4MWv9o5Dr8XgxY/XoPsvto5Dr/F+zA/wemivto5Dr9Mp0Q/0Romvto5Dr8pxFA/Q8tqpNo5Dr8x21Q/0RomPto5Dr8pxFA/wemiPto5Dr9Mp0Q/XoPsPto5Dr/F+zA/F4MWP9o5Dr8XgxY/xfswP9o5Dr9eg+w+TKdEP9o5Dr/B6aI+KcRQP9o5Dr/RGiY+MdtUP9o5Dr9Dy+okKcRQP9o5Dr/RGia+TKdEP9o5Dr/B6aK+xfswP9o5Dr9eg+y+F4MWP9o5Dr8Xgxa/XoPsPto5Dr/F+zC/wemiPto5Dr9Mp0S/0RomPto5Dr8pxFC/chgwJdo5Dr8x21S/0Romvto5Dr8pxFC/wemivto5Dr9Mp0S/XoPsvto5Dr/F+zC/F4MWv9o5Dr8Xgxa/xfswv9o5Dr9eg+y+TKdEv9o5Dr/B6aK+KcRQv9o5Dr/RGia+MdtUv9o5Dr9Dy2ql8wQ1v/MENb8AAAAAhooxv/MENb+vQg0+dT0nv/MENb/Ui4o+F4MWv/MENb9OI8k+AAAAv/MENb8AAAA/TiPJvvMENb8XgxY/1IuKvvMENb91PSc/r0INvvMENb+GijE/Bq1HpPMENb/zBDU/r0INPvMENb+GijE/1IuKPvMENb91PSc/TiPJPvMENb8XgxY/AAAAP/MENb8AAAA/F4MWP/MENb9OI8k+dT0nP/MENb/Ui4o+hooxP/MENb+vQg0+8wQ1P/MENb8GrcckhooxP/MENb+vQg2+dT0nP/MENb/Ui4q+F4MWP/MENb9OI8m+AAAAP/MENb8AAAC/TiPJPvMENb8Xgxa/1IuKPvMENb91PSe/r0INPvMENb+GijG/xMEVJfMENb/zBDW/r0INvvMENb+GijG/1IuKvvMENb91PSe/TiPJvvMENb8Xgxa/AAAAv/MENb8AAAC/F4MWv/MENb9OI8m+dT0nv/MENb/Ui4q+hooxv/MENb+vQg2+8wQ1v/MENb8GrUel2jkOvzHbVL8AAAAAP34LvzHbVL+t+d09UWYDvzHbVL/JtVk+XoPsvjHbVL91CJ4+TiPJvjHbVL9OI8k+dQievjHbVL9eg+w+ybVZvjHbVL9RZgM/rfndvTHbVL8/fgs/Y+IcpDHbVL/aOQ4/rfndPTHbVL8/fgs/ybVZPjHbVL9RZgM/dQiePjHbVL9eg+w+TiPJPjHbVL9OI8k+XoPsPjHbVL91CJ4+UWYDPzHbVL/JtVk+P34LPzHbVL+t+d092jkOPzHbVL9j4pwkP34LPzHbVL+t+d29UWYDPzHbVL/JtVm+XoPsPjHbVL91CJ6+TiPJPjHbVL9OI8m+dQiePjHbVL9eg+y+ybVZPjHbVL9RZgO/rfndPTHbVL8/fgu/lVPrJDHbVL/aOQ6/rfndvTHbVL8/fgu/ybVZvjHbVL9RZgO/dQievjHbVL9eg+y+TiPJvjHbVL9OI8m+XoPsvjHbVL91CJ6+UWYDvzHbVL/JtVm+P34LvzHbVL+t+d292jkOvzHbVL9j4hylFe/Dvl6DbL8AAAAASivAvl6DbL815pg98wS1vl6DbL8a9hU+wemivl6DbL/JtVk+1IuKvl6DbL/Ui4o+ybVZvl6DbL/B6aI+GvYVvl6DbL/zBLU+NeaYvV6DbL9KK8A+qyDYo16DbL8V78M+NeaYPV6DbL9KK8A+GvYVPl6DbL/zBLU+ybVZPl6DbL/B6aI+1IuKPl6DbL/Ui4o+wemiPl6DbL/JtVk+8wS1Pl6DbL8a9hU+SivAPl6DbL815pg9Fe/DPl6DbL+rIFgkSivAPl6DbL815pi98wS1Pl6DbL8a9hW+wemiPl6DbL/JtVm+1IuKPl6DbL/Ui4q+ybVZPl6DbL/B6aK+GvYVPl6DbL/zBLW+NeaYPV6DbL9KK8C+gBiiJF6DbL8V78O+NeaYvV6DbL9KK8C+GvYVvl6DbL/zBLW+ybVZvl6DbL/B6aK+1IuKvl6DbL/Ui4q+wemivl6DbL/JtVm+8wS1vl6DbL8a9hW+SivAvl6DbL815pi9Fe/Dvl6DbL+rINikwsVHvr4Ue78AAAAAFe9Dvr4Ue78M5Rs905A4vr4Ue7815pg90Romvr4Ue7+t+d09r0INvr4Ue7+vQg0+rfndvb4Ue7/RGiY+NeaYvb4Ue7/TkDg+DOUbvb4Ue78V70M+n1xco74Ue7/CxUc+DOUbPb4Ue78V70M+NeaYPb4Ue7/TkDg+rfndPb4Ue7/RGiY+r0INPr4Ue7+vQg0+0RomPr4Ue7+t+d0905A4Pr4Ue7815pg9Fe9DPr4Ue78M5Rs9wsVHPr4Ue7+fXNwjFe9DPr4Ue78M5Ru905A4Pr4Ue7815pi90RomPr4Ue7+t+d29r0INPr4Ue7+vQg2+rfndPb4Ue7/RGia+NeaYPb4Ue7/TkDi+DOUbPb4Ue78V70O+d0UlJL4Ue7/CxUe+DOUbvb4Ue78V70O+NeaYvb4Ue7/TkDi+rfndvb4Ue7/RGia+r0INvr4Ue7+vQg2+0Romvr4Ue7+t+d2905A4vr4Ue7815pi9Fe9Dvr4Ue78M5Ru9wsVHvr4Ue7+fXFykMjENpQAAgL8AAAAArXoKpQAAgL+fXNwjznECpQAAgL+rIFgkQ8vqpAAAgL9j4pwkBq3HpAAAgL8GrcckY+KcpAAAgL9Dy+okqyBYpAAAgL/OcQIln1zcowAAgL+tegoldL4bigAAgL8yMQ0ln1zcIwAAgL+tegolqyBYJAAAgL/OcQIlY+KcJAAAgL9Dy+okBq3HJAAAgL8GrcckQ8vqJAAAgL9j4pwkznECJQAAgL+rIFgkrXoKJQAAgL+fXNwjMjENJQAAgL90vpsKrXoKJQAAgL+fXNyjznECJQAAgL+rIFikQ8vqJAAAgL9j4pykBq3HJAAAgL8GrcekY+KcJAAAgL9Dy+qkqyBYJAAAgL/OcQKln1zcIwAAgL+tegqlrp3pCgAAgL8yMQ2ln1zcowAAgL+tegqlqyBYpAAAgL/OcQKlY+KcpAAAgL9Dy+qkBq3HpAAAgL8GrcekQ8vqpAAAgL9j4pykznECpQAAgL+rIFikrXoKpQAAgL+fXNyjMjENpQAAgL90vhuL",
-        "encoding": "base64",
-        "path": [
-         "array",
-         "buffer"
-        ]
-       }
-      ],
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "BufferAttributeModel",
-      "state": {
-       "array": {
-        "buffer": {},
-        "dtype": "float32",
-        "shape": [
-         561,
-         3
-        ]
-       },
-       "normalized": false,
-       "version": 0
-      }
-     },
-     "46dc4bc928c140c9b2157106d045b539": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationClipModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "duration": 3,
-       "tracks": [
-        "IPY_MODEL_85871ed2b4304b468017a36c0caa1654"
-       ]
-      }
-     },
-     "48fcb06537f947ce9612c9e5eb40f45e": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "RendererModel",
-      "state": {
-       "_height": 400,
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "_width": 600,
-       "camera": "IPY_MODEL_f9c4682a3f104f8da8791d52b4ba43b0",
-       "controls": [
-        "IPY_MODEL_7f95e3b9fa9241199300388e28a2e749"
-       ],
-       "layout": "IPY_MODEL_7d50dc5e342d4e7ebfa4e34b81f99426",
-       "scene": "IPY_MODEL_569949363397473c80b966a1ea8bae98",
-       "shadowMap": "IPY_MODEL_9667124ba7234e2ea16f67a72e850438"
-      }
-     },
-     "4abd8adb5df6411886e59d5d00e495ea": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "SphereBufferGeometryModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "heightSegments": 16,
-       "radius": 1,
-       "type": "SphereBufferGeometry",
-       "widthSegments": 32
-      }
-     },
-     "4acda7189a3a4f6282b8d352cc72b5c8": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "OrbitControlsModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "controlling": "IPY_MODEL_cf16a07a48474bdbb5d94e346d149062",
-       "maxAzimuthAngle": "inf",
-       "maxDistance": "inf",
-       "maxZoom": "inf",
-       "minAzimuthAngle": "-inf"
-      }
-     },
-     "4af1d948fce7444ead8d2497229bf283": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "CylinderGeometryModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "height": 50,
-       "heightSegments": 15,
-       "openEnded": true,
-       "radiusBottom": 5,
-       "radiusSegments": 5,
-       "radiusTop": 5,
-       "type": "CylinderGeometry"
-      }
-     },
-     "4c786986-1d83-4b71-9663-198dca377027": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "OrthographicCameraModel",
-      "state": {
-       "bottom": -5,
-       "far": 500,
-       "left": -5,
-       "near": 0.5,
-       "projectionMatrix": [
-        0.2,
-        0,
-        0,
-        0,
-        0,
-        0.2,
-        0,
-        0,
-        0,
-        0,
-        -0.004004004004004004,
-        0,
-        0,
-        0,
-        -1.002002002002002,
-        1
-       ],
-       "right": 5,
-       "top": 5,
-       "type": "OrthographicCamera"
-      }
-     },
-     "50152692-311a-48a1-ba3d-a87b797d2d2a": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "Object3DModel",
-      "state": {
-       "type": "Object3D"
-      }
-     },
-     "50801120cfdb4f4f91599c0c9aeef939": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "MeshModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "geometry": "IPY_MODEL_c041c44e665947fa9ed8a427a5a5abb8",
-       "material": "IPY_MODEL_02829a2eeab04a448f0ce62331791cf9",
-       "morphTargetInfluences": [],
-       "type": "Mesh"
-      }
-     },
-     "52ccaf76ffc546fcba84fcceeaf68a02": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "MeshLambertMaterialModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "color": "green",
-       "type": "MeshLambertMaterial"
-      }
-     },
-     "54924996-dc91-485a-bfab-d74b7a231bc4": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "DirectionalLightShadowModel",
-      "state": {
-       "camera": "IPY_MODEL_3e0d84be-3813-45f9-a6ce-e1cd1346287d"
-      }
-     },
-     "56457e19a7684decb50af664d17dc999": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationClipModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "duration": 2,
-       "tracks": [
-        "IPY_MODEL_5ffa9d093adb425493886d10fc8209f7",
-        "IPY_MODEL_bfb4e453ce1844e18319bf97b1fc36c9",
-        "IPY_MODEL_17427107af1e42b98d19690a4b48647b",
-        "IPY_MODEL_c120390348ba4b319f14b132152ea0fa"
-       ]
-      }
-     },
-     "569949363397473c80b966a1ea8bae98": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "SceneModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "children": [
-        "IPY_MODEL_cf7eef49fa254c968cc35664bb385f72",
-        "IPY_MODEL_f9c4682a3f104f8da8791d52b4ba43b0",
-        "IPY_MODEL_f9f842841acc413287cb13f3592b5445",
-        "IPY_MODEL_7d56bcb4b3f9456597c36a1b6d75c09f"
-       ],
-       "type": "Scene"
-      }
-     },
-     "589f9d46-960f-42c9-8991-c5c341dea1a0": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "DirectionalLightShadowModel",
-      "state": {
-       "camera": "IPY_MODEL_341dd569-5c9f-4bb7-b459-3df244122885"
-      }
-     },
-     "5b9162ac5f1d403f887f2a4c21308f0f": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "BoxBufferGeometryModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "depth": 1,
-       "height": 1,
-       "type": "BoxBufferGeometry",
-       "width": 1
-      }
-     },
-     "5ca0b95203774d8ca9f3febbda13f4d7": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationMixerModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "rootObject": "IPY_MODEL_7d4b7c8ad9cd454499e2b4e6f814c316"
-      }
-     },
-     "5ffa9d093adb425493886d10fc8209f7": {
-      "buffers": [
-       {
-        "data": "AAAAAAAAAD8AAMA/AAAAQA==",
-        "encoding": "base64",
-        "path": [
-         "times",
-         "buffer"
-        ]
-       },
-       {
-        "data": "AAAAAJqZmT6amZm+AAAAAA==",
-        "encoding": "base64",
-        "path": [
-         "values",
-         "buffer"
-        ]
-       }
-      ],
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "NumberKeyframeTrackModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "name": ".bones[1].rotation[x]",
-       "times": {
-        "buffer": {},
-        "dtype": "float32",
-        "shape": [
-         4
-        ]
-       },
-       "values": {
-        "buffer": {},
-        "dtype": "float32",
-        "shape": [
-         4
-        ]
-       }
-      }
-     },
-     "60479798418c4628bdfe44c8561b6a27": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "MeshPhysicalMaterialModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "color": "green",
-       "type": "MeshPhysicalMaterial"
-      }
-     },
-     "6379f3052dcd4a5d85bc5fd1d4c83e4a": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "MeshModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "geometry": "IPY_MODEL_5b9162ac5f1d403f887f2a4c21308f0f",
-       "material": "IPY_MODEL_60479798418c4628bdfe44c8561b6a27",
-       "morphTargetInfluences": [],
-       "position": [
-        2,
-        0,
-        4
-       ],
-       "type": "Mesh"
-      }
-     },
-     "6744d9394cfa4b79bcd76b176a91365d": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "68a30b6a-5a07-4fa5-84b2-57e47481f497": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "Object3DModel",
-      "state": {
-       "type": "Object3D"
-      }
-     },
-     "693926a4dc5c4995bde2013b3398183d": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "6a36d1d9a40f4ec4b5b79b9fd2c09089": {
-      "buffers": [
-       {
-        "data": "AAAAAAIAAAA=",
-        "encoding": "base64",
-        "path": [
-         "times",
-         "buffer"
-        ]
-       },
-       {
-        "data": "AAAAAMP1yEA=",
-        "encoding": "base64",
-        "path": [
-         "values",
-         "buffer"
-        ]
-       }
-      ],
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "NumberKeyframeTrackModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "name": ".rotation[y]",
-       "times": {
-        "buffer": {},
-        "dtype": "int32",
-        "shape": [
-         2
-        ]
-       },
-       "values": {
-        "buffer": {},
-        "dtype": "float32",
-        "shape": [
-         2
-        ]
-       }
-      }
-     },
-     "6a5ca85a20624e7fb0ab33c17207bccc": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "BoneModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "position": [
-        0,
-        25,
-        0
-       ],
-       "type": "Bone"
-      }
-     },
-     "6c31ee21ad86476bb751c99004ebce15": {
-      "buffers": [
-       {
-        "data": "AAAAAAIAAAAFAAAA",
-        "encoding": "base64",
-        "path": [
-         "times",
-         "buffer"
-        ]
-       },
-       {
-        "data": "AAAgQQAAwEAAACBBmpnJQIXrcUCamclAUrg+wD0KVz8zMxNB",
-        "encoding": "base64",
-        "path": [
-         "values",
-         "buffer"
-        ]
-       }
-      ],
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "VectorKeyframeTrackModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "name": ".position",
-       "times": {
-        "buffer": {},
-        "dtype": "int32",
-        "shape": [
-         3
-        ]
-       },
-       "values": {
-        "buffer": {},
-        "dtype": "float32",
-        "shape": [
-         9
-        ]
-       }
-      }
-     },
-     "7586b9bde0714d409c8736821df5aff3": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "SceneModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "children": [
-        "IPY_MODEL_7d4b7c8ad9cd454499e2b4e6f814c316",
-        "IPY_MODEL_85ad1b701cc24caeacb68335a58cd2bc",
-        "IPY_MODEL_cf16a07a48474bdbb5d94e346d149062",
-        "IPY_MODEL_30cec7cc2ef24f12a555c1d7504727d2",
-        "IPY_MODEL_d0c51440612745b2a66593eac869058b"
-       ],
-       "type": "Scene"
-      }
-     },
-     "765ce8e93d564b0d984bf95de376ed29": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "BoneModel",
       "state": {
        "_view_module": null,
        "_view_module_version": "",
        "children": [
-        "IPY_MODEL_879eb5734d2449879b914dd56facfed0"
+        "IPY_MODEL_fe7d6be53ed14f83aefad6e22b36689b"
        ],
        "position": [
         0,
@@ -1810,71 +874,7 @@
        "type": "Bone"
       }
      },
-     "7d4b7c8ad9cd454499e2b4e6f814c316": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "SkinnedMeshModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "children": [
-        "IPY_MODEL_765ce8e93d564b0d984bf95de376ed29"
-       ],
-       "geometry": "IPY_MODEL_16e2a1bfed974746b0d73bff9542af6d",
-       "material": "IPY_MODEL_09db366bb99a42629d43eb33be5eb041",
-       "morphTargetInfluences": [],
-       "skeleton": "IPY_MODEL_b035c6b558db4d6c8f1d1d5d5ec3de97",
-       "type": "SkinnedMesh"
-      }
-     },
-     "7d50dc5e342d4e7ebfa4e34b81f99426": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "7d56bcb4b3f9456597c36a1b6d75c09f": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AmbientLightModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "intensity": 0.5,
-       "type": "AmbientLight"
-      }
-     },
-     "7e366662527d4c85bed775032c5836bd": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationActionModel",
-      "state": {
-       "_model_module": "jupyter-threejs",
-       "_model_module_version": "0.4.0",
-       "_model_name": "AnimationActionModel",
-       "_view_module_version": "0.4.0",
-       "clip": "IPY_MODEL_178b9b11bc384f05a93a936ed6b09886",
-       "layout": "IPY_MODEL_693926a4dc5c4995bde2013b3398183d",
-       "localRoot": "IPY_MODEL_40bc08d47f60411186632f40b42248b5",
-       "mixer": "IPY_MODEL_beb875f49714431ca1d99e22d74a53c2",
-       "repititions": "inf"
-      }
-     },
-     "7f95e3b9fa9241199300388e28a2e749": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "OrbitControlsModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "controlling": "IPY_MODEL_f9c4682a3f104f8da8791d52b4ba43b0",
-       "maxAzimuthAngle": "inf",
-       "maxDistance": "inf",
-       "maxZoom": "inf",
-       "minAzimuthAngle": "-inf"
-      }
-     },
-     "81ad38301eff4ae499251bb76eda7db7": {
+     "04f524ee1fff4e949f18831f62b60ee0": {
       "buffers": [
        {
         "data": "AAAAAAIAAAAFAAAA",
@@ -1894,21 +894,20 @@
        }
       ],
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "QuaternionKeyframeTrackModel",
       "state": {
        "_view_module": null,
        "_view_module_version": "",
        "name": ".quaternion",
        "times": {
-        "buffer": {},
         "dtype": "int32",
         "shape": [
          3
         ]
        },
+       "type": "Bone",
        "values": {
-        "buffer": {},
         "dtype": "float32",
         "shape": [
          12
@@ -1916,347 +915,37 @@
        }
       }
      },
-     "85871ed2b4304b468017a36c0caa1654": {
-      "buffers": [
-       {
-        "data": "AAAAAAAAwD8AAEBA",
-        "encoding": "base64",
-        "path": [
-         "times",
-         "buffer"
-        ]
-       },
-       {
-        "data": "AAAAAAAAIEAAAAAA",
-        "encoding": "base64",
-        "path": [
-         "values",
-         "buffer"
-        ]
-       }
-      ],
+     "0568aa6c-903a-43ec-9048-d80ce23b1bc9": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "NumberKeyframeTrackModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "Object3DModel",
+      "state": {
+       "type": "Object3D"
+      }
+     },
+     "05e624ff-8139-4a39-bfc2-866842091a87": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "Object3DModel",
+      "state": {
+       "type": "Object3D"
+      }
+     },
+     "06b9defcec5d43c590ef3a90b183a850": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "OrbitControlsModel",
       "state": {
        "_view_module": null,
        "_view_module_version": "",
-       "name": ".morphTargetInfluences[0]",
-       "times": {
-        "buffer": {},
-        "dtype": "float32",
-        "shape": [
-         3
-        ]
-       },
-       "values": {
-        "buffer": {},
-        "dtype": "float32",
-        "shape": [
-         3
-        ]
-       }
+       "controlling": "IPY_MODEL_57273feb5932436482db5fdb2fef14c1",
+       "maxAzimuthAngle": "inf",
+       "maxDistance": "inf",
+       "maxZoom": "inf",
+       "minAzimuthAngle": "-inf"
       }
      },
-     "85ad1b701cc24caeacb68335a58cd2bc": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "SkeletonHelperModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "root": "IPY_MODEL_7d4b7c8ad9cd454499e2b4e6f814c316",
-       "type": "LineSegments"
-      }
-     },
-     "879eb5734d2449879b914dd56facfed0": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "BoneModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "children": [
-        "IPY_MODEL_6a5ca85a20624e7fb0ab33c17207bccc"
-       ],
-       "position": [
-        0,
-        25,
-        0
-       ],
-       "type": "Bone"
-      }
-     },
-     "88fded967d154b94a5dc53d2691b1614": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "940459e3-ab89-4372-b343-1451541aeb6c": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "DirectionalLightShadowModel",
-      "state": {
-       "camera": "IPY_MODEL_4c786986-1d83-4b71-9663-198dca377027"
-      }
-     },
-     "9667124ba7234e2ea16f67a72e850438": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "96d31bd0f71b474b9950367ad61d4a9d": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PerspectiveCameraModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "aspect": 1.5,
-       "position": [
-        10,
-        6,
-        10
-       ],
-       "projectionMatrix": [
-        1.4296712803397058,
-        0,
-        0,
-        0,
-        0,
-        2.1445069205095586,
-        0,
-        0,
-        0,
-        0,
-        -1.00010000500025,
-        -1,
-        0,
-        0,
-        -0.200010000500025,
-        0
-       ],
-       "type": "PerspectiveCamera"
-      }
-     },
-     "996f8357-ecae-4c17-b429-27b1ef19b665": {
-      "buffers": [
-       {
-        "data": "AAAAAAAAgD8AAAA9AACAPwAAgD0AAIA/AADAPQAAgD8AAAA+AACAPwAAID4AAIA/AABAPgAAgD8AAGA+AACAPwAAgD4AAIA/AACQPgAAgD8AAKA+AACAPwAAsD4AAIA/AADAPgAAgD8AANA+AACAPwAA4D4AAIA/AADwPgAAgD8AAAA/AACAPwAACD8AAIA/AAAQPwAAgD8AABg/AACAPwAAID8AAIA/AAAoPwAAgD8AADA/AACAPwAAOD8AAIA/AABAPwAAgD8AAEg/AACAPwAAUD8AAIA/AABYPwAAgD8AAGA/AACAPwAAaD8AAIA/AABwPwAAgD8AAHg/AACAPwAAgD8AAIA/AAAAAAAAcD8AAAA9AABwPwAAgD0AAHA/AADAPQAAcD8AAAA+AABwPwAAID4AAHA/AABAPgAAcD8AAGA+AABwPwAAgD4AAHA/AACQPgAAcD8AAKA+AABwPwAAsD4AAHA/AADAPgAAcD8AANA+AABwPwAA4D4AAHA/AADwPgAAcD8AAAA/AABwPwAACD8AAHA/AAAQPwAAcD8AABg/AABwPwAAID8AAHA/AAAoPwAAcD8AADA/AABwPwAAOD8AAHA/AABAPwAAcD8AAEg/AABwPwAAUD8AAHA/AABYPwAAcD8AAGA/AABwPwAAaD8AAHA/AABwPwAAcD8AAHg/AABwPwAAgD8AAHA/AAAAAAAAYD8AAAA9AABgPwAAgD0AAGA/AADAPQAAYD8AAAA+AABgPwAAID4AAGA/AABAPgAAYD8AAGA+AABgPwAAgD4AAGA/AACQPgAAYD8AAKA+AABgPwAAsD4AAGA/AADAPgAAYD8AANA+AABgPwAA4D4AAGA/AADwPgAAYD8AAAA/AABgPwAACD8AAGA/AAAQPwAAYD8AABg/AABgPwAAID8AAGA/AAAoPwAAYD8AADA/AABgPwAAOD8AAGA/AABAPwAAYD8AAEg/AABgPwAAUD8AAGA/AABYPwAAYD8AAGA/AABgPwAAaD8AAGA/AABwPwAAYD8AAHg/AABgPwAAgD8AAGA/AAAAAAAAUD8AAAA9AABQPwAAgD0AAFA/AADAPQAAUD8AAAA+AABQPwAAID4AAFA/AABAPgAAUD8AAGA+AABQPwAAgD4AAFA/AACQPgAAUD8AAKA+AABQPwAAsD4AAFA/AADAPgAAUD8AANA+AABQPwAA4D4AAFA/AADwPgAAUD8AAAA/AABQPwAACD8AAFA/AAAQPwAAUD8AABg/AABQPwAAID8AAFA/AAAoPwAAUD8AADA/AABQPwAAOD8AAFA/AABAPwAAUD8AAEg/AABQPwAAUD8AAFA/AABYPwAAUD8AAGA/AABQPwAAaD8AAFA/AABwPwAAUD8AAHg/AABQPwAAgD8AAFA/AAAAAAAAQD8AAAA9AABAPwAAgD0AAEA/AADAPQAAQD8AAAA+AABAPwAAID4AAEA/AABAPgAAQD8AAGA+AABAPwAAgD4AAEA/AACQPgAAQD8AAKA+AABAPwAAsD4AAEA/AADAPgAAQD8AANA+AABAPwAA4D4AAEA/AADwPgAAQD8AAAA/AABAPwAACD8AAEA/AAAQPwAAQD8AABg/AABAPwAAID8AAEA/AAAoPwAAQD8AADA/AABAPwAAOD8AAEA/AABAPwAAQD8AAEg/AABAPwAAUD8AAEA/AABYPwAAQD8AAGA/AABAPwAAaD8AAEA/AABwPwAAQD8AAHg/AABAPwAAgD8AAEA/AAAAAAAAMD8AAAA9AAAwPwAAgD0AADA/AADAPQAAMD8AAAA+AAAwPwAAID4AADA/AABAPgAAMD8AAGA+AAAwPwAAgD4AADA/AACQPgAAMD8AAKA+AAAwPwAAsD4AADA/AADAPgAAMD8AANA+AAAwPwAA4D4AADA/AADwPgAAMD8AAAA/AAAwPwAACD8AADA/AAAQPwAAMD8AABg/AAAwPwAAID8AADA/AAAoPwAAMD8AADA/AAAwPwAAOD8AADA/AABAPwAAMD8AAEg/AAAwPwAAUD8AADA/AABYPwAAMD8AAGA/AAAwPwAAaD8AADA/AABwPwAAMD8AAHg/AAAwPwAAgD8AADA/AAAAAAAAID8AAAA9AAAgPwAAgD0AACA/AADAPQAAID8AAAA+AAAgPwAAID4AACA/AABAPgAAID8AAGA+AAAgPwAAgD4AACA/AACQPgAAID8AAKA+AAAgPwAAsD4AACA/AADAPgAAID8AANA+AAAgPwAA4D4AACA/AADwPgAAID8AAAA/AAAgPwAACD8AACA/AAAQPwAAID8AABg/AAAgPwAAID8AACA/AAAoPwAAID8AADA/AAAgPwAAOD8AACA/AABAPwAAID8AAEg/AAAgPwAAUD8AACA/AABYPwAAID8AAGA/AAAgPwAAaD8AACA/AABwPwAAID8AAHg/AAAgPwAAgD8AACA/AAAAAAAAED8AAAA9AAAQPwAAgD0AABA/AADAPQAAED8AAAA+AAAQPwAAID4AABA/AABAPgAAED8AAGA+AAAQPwAAgD4AABA/AACQPgAAED8AAKA+AAAQPwAAsD4AABA/AADAPgAAED8AANA+AAAQPwAA4D4AABA/AADwPgAAED8AAAA/AAAQPwAACD8AABA/AAAQPwAAED8AABg/AAAQPwAAID8AABA/AAAoPwAAED8AADA/AAAQPwAAOD8AABA/AABAPwAAED8AAEg/AAAQPwAAUD8AABA/AABYPwAAED8AAGA/AAAQPwAAaD8AABA/AABwPwAAED8AAHg/AAAQPwAAgD8AABA/AAAAAAAAAD8AAAA9AAAAPwAAgD0AAAA/AADAPQAAAD8AAAA+AAAAPwAAID4AAAA/AABAPgAAAD8AAGA+AAAAPwAAgD4AAAA/AACQPgAAAD8AAKA+AAAAPwAAsD4AAAA/AADAPgAAAD8AANA+AAAAPwAA4D4AAAA/AADwPgAAAD8AAAA/AAAAPwAACD8AAAA/AAAQPwAAAD8AABg/AAAAPwAAID8AAAA/AAAoPwAAAD8AADA/AAAAPwAAOD8AAAA/AABAPwAAAD8AAEg/AAAAPwAAUD8AAAA/AABYPwAAAD8AAGA/AAAAPwAAaD8AAAA/AABwPwAAAD8AAHg/AAAAPwAAgD8AAAA/AAAAAAAA4D4AAAA9AADgPgAAgD0AAOA+AADAPQAA4D4AAAA+AADgPgAAID4AAOA+AABAPgAA4D4AAGA+AADgPgAAgD4AAOA+AACQPgAA4D4AAKA+AADgPgAAsD4AAOA+AADAPgAA4D4AANA+AADgPgAA4D4AAOA+AADwPgAA4D4AAAA/AADgPgAACD8AAOA+AAAQPwAA4D4AABg/AADgPgAAID8AAOA+AAAoPwAA4D4AADA/AADgPgAAOD8AAOA+AABAPwAA4D4AAEg/AADgPgAAUD8AAOA+AABYPwAA4D4AAGA/AADgPgAAaD8AAOA+AABwPwAA4D4AAHg/AADgPgAAgD8AAOA+AAAAAAAAwD4AAAA9AADAPgAAgD0AAMA+AADAPQAAwD4AAAA+AADAPgAAID4AAMA+AABAPgAAwD4AAGA+AADAPgAAgD4AAMA+AACQPgAAwD4AAKA+AADAPgAAsD4AAMA+AADAPgAAwD4AANA+AADAPgAA4D4AAMA+AADwPgAAwD4AAAA/AADAPgAACD8AAMA+AAAQPwAAwD4AABg/AADAPgAAID8AAMA+AAAoPwAAwD4AADA/AADAPgAAOD8AAMA+AABAPwAAwD4AAEg/AADAPgAAUD8AAMA+AABYPwAAwD4AAGA/AADAPgAAaD8AAMA+AABwPwAAwD4AAHg/AADAPgAAgD8AAMA+AAAAAAAAoD4AAAA9AACgPgAAgD0AAKA+AADAPQAAoD4AAAA+AACgPgAAID4AAKA+AABAPgAAoD4AAGA+AACgPgAAgD4AAKA+AACQPgAAoD4AAKA+AACgPgAAsD4AAKA+AADAPgAAoD4AANA+AACgPgAA4D4AAKA+AADwPgAAoD4AAAA/AACgPgAACD8AAKA+AAAQPwAAoD4AABg/AACgPgAAID8AAKA+AAAoPwAAoD4AADA/AACgPgAAOD8AAKA+AABAPwAAoD4AAEg/AACgPgAAUD8AAKA+AABYPwAAoD4AAGA/AACgPgAAaD8AAKA+AABwPwAAoD4AAHg/AACgPgAAgD8AAKA+AAAAAAAAgD4AAAA9AACAPgAAgD0AAIA+AADAPQAAgD4AAAA+AACAPgAAID4AAIA+AABAPgAAgD4AAGA+AACAPgAAgD4AAIA+AACQPgAAgD4AAKA+AACAPgAAsD4AAIA+AADAPgAAgD4AANA+AACAPgAA4D4AAIA+AADwPgAAgD4AAAA/AACAPgAACD8AAIA+AAAQPwAAgD4AABg/AACAPgAAID8AAIA+AAAoPwAAgD4AADA/AACAPgAAOD8AAIA+AABAPwAAgD4AAEg/AACAPgAAUD8AAIA+AABYPwAAgD4AAGA/AACAPgAAaD8AAIA+AABwPwAAgD4AAHg/AACAPgAAgD8AAIA+AAAAAAAAQD4AAAA9AABAPgAAgD0AAEA+AADAPQAAQD4AAAA+AABAPgAAID4AAEA+AABAPgAAQD4AAGA+AABAPgAAgD4AAEA+AACQPgAAQD4AAKA+AABAPgAAsD4AAEA+AADAPgAAQD4AANA+AABAPgAA4D4AAEA+AADwPgAAQD4AAAA/AABAPgAACD8AAEA+AAAQPwAAQD4AABg/AABAPgAAID8AAEA+AAAoPwAAQD4AADA/AABAPgAAOD8AAEA+AABAPwAAQD4AAEg/AABAPgAAUD8AAEA+AABYPwAAQD4AAGA/AABAPgAAaD8AAEA+AABwPwAAQD4AAHg/AABAPgAAgD8AAEA+AAAAAAAAAD4AAAA9AAAAPgAAgD0AAAA+AADAPQAAAD4AAAA+AAAAPgAAID4AAAA+AABAPgAAAD4AAGA+AAAAPgAAgD4AAAA+AACQPgAAAD4AAKA+AAAAPgAAsD4AAAA+AADAPgAAAD4AANA+AAAAPgAA4D4AAAA+AADwPgAAAD4AAAA/AAAAPgAACD8AAAA+AAAQPwAAAD4AABg/AAAAPgAAID8AAAA+AAAoPwAAAD4AADA/AAAAPgAAOD8AAAA+AABAPwAAAD4AAEg/AAAAPgAAUD8AAAA+AABYPwAAAD4AAGA/AAAAPgAAaD8AAAA+AABwPwAAAD4AAHg/AAAAPgAAgD8AAAA+AAAAAAAAgD0AAAA9AACAPQAAgD0AAIA9AADAPQAAgD0AAAA+AACAPQAAID4AAIA9AABAPgAAgD0AAGA+AACAPQAAgD4AAIA9AACQPgAAgD0AAKA+AACAPQAAsD4AAIA9AADAPgAAgD0AANA+AACAPQAA4D4AAIA9AADwPgAAgD0AAAA/AACAPQAACD8AAIA9AAAQPwAAgD0AABg/AACAPQAAID8AAIA9AAAoPwAAgD0AADA/AACAPQAAOD8AAIA9AABAPwAAgD0AAEg/AACAPQAAUD8AAIA9AABYPwAAgD0AAGA/AACAPQAAaD8AAIA9AABwPwAAgD0AAHg/AACAPQAAgD8AAIA9AAAAAAAAAAAAAAA9AAAAAAAAgD0AAAAAAADAPQAAAAAAAAA+AAAAAAAAID4AAAAAAABAPgAAAAAAAGA+AAAAAAAAgD4AAAAAAACQPgAAAAAAAKA+AAAAAAAAsD4AAAAAAADAPgAAAAAAANA+AAAAAAAA4D4AAAAAAADwPgAAAAAAAAA/AAAAAAAACD8AAAAAAAAQPwAAAAAAABg/AAAAAAAAID8AAAAAAAAoPwAAAAAAADA/AAAAAAAAOD8AAAAAAABAPwAAAAAAAEg/AAAAAAAAUD8AAAAAAABYPwAAAAAAAGA/AAAAAAAAaD8AAAAAAABwPwAAAAAAAHg/AAAAAAAAgD8AAAAA",
-        "encoding": "base64",
-        "path": [
-         "array",
-         "buffer"
-        ]
-       }
-      ],
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "BufferAttributeModel",
-      "state": {
-       "array": {
-        "buffer": {},
-        "dtype": "float32",
-        "shape": [
-         561,
-         2
-        ]
-       },
-       "normalized": false,
-       "version": 0
-      }
-     },
-     "9b221fa874364a28b5dd6d8a99894596": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AmbientLightModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "type": "AmbientLight"
-      }
-     },
-     "a127865d807f449aa2f54cdb2cd80b5b": {
-      "buffers": [
-       {
-        "data": "AAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAwsVHvr4Uez8AAAAAFe9Dvr4Uez8M5Rs905A4vr4Uez815pg90Romvr4Uez+t+d09r0INvr4Uez+vQg0+rfndvb4Uez/RGiY+NeaYvb4Uez/TkDg+DOUbvb4Uez8V70M+n1xco74Uez/CxUc+KN+EP74Uez8V70M+Y46JP74Uez/TkDg+m9+NP74Uez/RGiY+VqiRP74Uez+vQg0+WsOUP74Uez+t+d09GhKXP74Uez815pg9432YP74Uez8M5Rs9uPiYP74Uez+fXNwj432YP74Uez8M5Ru9GhKXP74Uez815pi9WsOUP74Uez+t+d29VqiRP74Uez+vQg2+m9+NP74Uez/RGia+Y46JP74Uez/TkDi+KN+EP74Uez8V70O+AACAP74Uez/CxUe+DOUbvb4Uez8V70O+NeaYvb4Uez/TkDi+rfndvb4Uez/RGia+r0INvr4Uez+vQg2+0Romvr4Uez+t+d2905A4vr4Uez815pi9Fe9Dvr4Uez8M5Ru9wsVHvr4Uez+fXFykFe/Dvl6DbD8AAAAASivAvl6DbD815pg98wS1vl6DbD8a9hU+wemivl6DbD/JtVk+1IuKvl6DbD/Ui4o+ybVZvl6DbD/B6aI+GvYVvl6DbD/zBLU+NeaYvV6DbD9KK8A+qyDYo16DbD8V78M+Y46JP16DbD9KK8A+w76SP16DbD/zBLU+uTabP16DbD/B6aI+9aKiP16DbD/Ui4o+cLqoP16DbD/JtVk+PUGtP16DbD8a9hU+0gqwP16DbD815pg9xfuwP16DbD+rIFgk0gqwP16DbD815pi9PUGtP16DbD8a9hW+cLqoP16DbD/JtVm+9aKiP16DbD/Ui4q+uTabP16DbD/B6aK+w76SP16DbD/zBLW+Y46JP16DbD9KK8C+AACAP16DbD8V78O+NeaYvV6DbD9KK8C+GvYVvl6DbD/zBLW+ybVZvl6DbD/B6aK+1IuKvl6DbD/Ui4q+wemivl6DbD/JtVm+8wS1vl6DbD8a9hW+SivAvl6DbD815pi9Fe/Dvl6DbD+rINik2jkOvzHbVD8AAAAAP34LvzHbVD+t+d09UWYDvzHbVD/JtVk+XoPsvjHbVD91CJ4+TiPJvjHbVD9OI8k+dQievjHbVD9eg+w+ybVZvjHbVD9RZgM/rfndvTHbVD8/fgs/Y+IcpDHbVD/aOQ4/m9+NPzHbVD8/fgs/uTabPzHbVD9RZgM/HYKnPzHbVD9eg+w+1EiyPzHbVD9OI8k+2CC7PzHbVD91CJ4+KLPBPzHbVD/JtVk+IL/FPzHbVD+t+d097RzHPzHbVD9j4pwkIL/FPzHbVD+t+d29KLPBPzHbVD/JtVm+2CC7PzHbVD91CJ6+1EiyPzHbVD9OI8m+HYKnPzHbVD9eg+y+uTabPzHbVD9RZgO/m9+NPzHbVD8/fgu/AACAPzHbVD/aOQ6/rfndvTHbVD8/fgu/ybVZvjHbVD9RZgO/dQievjHbVD9eg+y+TiPJvjHbVD9OI8m+XoPsvjHbVD91CJ6+UWYDvzHbVD/JtVm+P34LvzHbVD+t+d292jkOvzHbVD9j4hyl8wQ1v/MENT8AAAAAhooxv/MENT+vQg0+dT0nv/MENT/Ui4o+F4MWv/MENT9OI8k+AAAAv/MENT8AAAA/TiPJvvMENT8XgxY/1IuKvvMENT91PSc/r0INvvMENT+GijE/Bq1HpPMENT/zBDU/VqiRP/MENT+GijE/9aKiP/MENT91PSc/1EiyP/MENT8XgxY/AADAP/MENT8AAAA/jEHLP/MENT9OI8k+up7TP/MENT/Ui4o+Q8XYP/MENT+vQg0+eoLaP/MENT8GrcckQ8XYP/MENT+vQg2+up7TP/MENT/Ui4q+jEHLP/MENT9OI8m+AADAP/MENT8AAAC/1EiyP/MENT8Xgxa/9aKiP/MENT91PSe/VqiRP/MENT+GijG/AACAP/MENT/zBDW/r0INvvMENT+GijG/1IuKvvMENT91PSe/TiPJvvMENT8Xgxa/AAAAv/MENT8AAAC/F4MWv/MENT9OI8m+dT0nv/MENT/Ui4q+hooxv/MENT+vQg2+8wQ1v/MENT8GrUelMdtUv9o5Dj8AAAAAKcRQv9o5Dj/RGiY+TKdEv9o5Dj/B6aI+xfswv9o5Dj9eg+w+F4MWv9o5Dj8XgxY/XoPsvto5Dj/F+zA/wemivto5Dj9Mp0Q/0Romvto5Dj8pxFA/Q8tqpNo5Dj8x21Q/WsOUP9o5Dj8pxFA/cLqoP9o5Dj9Mp0Q/2CC7P9o5Dj/F+zA/jEHLP9o5Dj8XgxY/4n3YP9o5Dj9eg+w+plPiP9o5Dj/B6aI+FGLoP9o5Dj/RGiY+mG3qP9o5Dj9Dy+okFGLoP9o5Dj/RGia+plPiP9o5Dj/B6aK+4n3YP9o5Dj9eg+y+jEHLP9o5Dj8Xgxa/2CC7P9o5Dj/F+zC/cLqoP9o5Dj9Mp0S/WsOUP9o5Dj8pxFC/AACAP9o5Dj8x21S/0Romvto5Dj8pxFC/wemivto5Dj9Mp0S/XoPsvto5Dj/F+zC/F4MWv9o5Dj8Xgxa/xfswv9o5Dj9eg+y+TKdEv9o5Dj/B6aK+KcRQv9o5Dj/RGia+MdtUv9o5Dj9Dy2qlXoNsvxXvwz4AAAAA+PdnvxXvwz7TkDg+eoJavxXvwz7zBLU+TKdEvxXvwz5RZgM/dT0nvxXvwz51PSc/UWYDvxXvwz5Mp0Q/8wS1vhXvwz56glo/05A4vhXvwz7492c/znGCpBXvwz5eg2w/GhKXPxXvwz7492c/PUGtPxXvwz56glo/KLPBPxXvwz5Mp0Q/up7TPxXvwz51PSc/plPiPxXvwz5RZgM/PUHtPxXvwz7zBLU+/PvzPxXvwz7TkDg+r0H2PxXvwz7OcQIl/PvzPxXvwz7TkDi+PUHtPxXvwz7zBLW+plPiPxXvwz5RZgO/up7TPxXvwz51PSe/KLPBPxXvwz5Mp0S/PUGtPxXvwz56glq/GhKXPxXvwz7492e/AACAPxXvwz5eg2y/05A4vhXvwz7492e/8wS1vhXvwz56glq/UWYDvxXvwz5Mp0S/dT0nvxXvwz51PSe/TKdEvxXvwz5RZgO/eoJavxXvwz7zBLW++PdnvxXvwz7TkDi+XoNsvxXvwz7OcYKlvhR7v8LFRz4AAAAAr0F2v8LFRz4V70M++Pdnv8LFRz5KK8A+KcRQv8LFRz4/fgs/hooxv8LFRz6GijE/P34Lv8LFRz4pxFA/SivAvsLFRz7492c/Fe9DvsLFRz6vQXY/rXqKpMLFRz6+FHs/432YP8LFRz6vQXY/0gqwP8LFRz7492c/IL/FP8LFRz4pxFA/Q8XYP8LFRz6GijE/FGLoP8LFRz4/fgs//PvzP8LFRz5KK8A+2CD7P8LFRz4V70M+X4r9P8LFRz6tegol2CD7P8LFRz4V70O+/PvzP8LFRz5KK8C+FGLoP8LFRz4/fgu/Q8XYP8LFRz6GijG/IL/FP8LFRz4pxFC/0gqwP8LFRz7492e/432YP8LFRz6vQXa/AACAP8LFRz6+FHu/Fe9DvsLFRz6vQXa/SivAvsLFRz7492e/P34Lv8LFRz4pxFC/hooxv8LFRz6GijG/KcRQv8LFRz4/fgu/+Pdnv8LFRz5KK8C+r0F2v8LFRz4V70O+vhR7v8LFRz6teoqlAACAvzIxjSQAAAAAvhR7vzIxjSTCxUc+XoNsvzIxjSQV78M+MdtUvzIxjSTaOQ4/8wQ1vzIxjSTzBDU/2jkOvzIxjSQx21Q/Fe/DvjIxjSReg2w/wsVHvjIxjSS+FHs/MjGNpDIxjSQAAIA/uPiYPzIxjSS+FHs/xfuwPzIxjSReg2w/7RzHPzIxjSQx21Q/eoLaPzIxjSTzBDU/mG3qPzIxjSTaOQ4/r0H2PzIxjSQV78M+X4r9PzIxjSTCxUc+AAAAQDIxjSQyMQ0lX4r9PzIxjSTCxUe+r0H2PzIxjSQV78O+mG3qPzIxjSTaOQ6/eoLaPzIxjSTzBDW/7RzHPzIxjSQx21S/xfuwPzIxjSReg2y/uPiYPzIxjSS+FHu/AACAPzIxjSQAAIC/wsVHvjIxjSS+FHu/Fe/DvjIxjSReg2y/2jkOvzIxjSQx21S/8wQ1vzIxjSTzBDW/MdtUvzIxjSTaOQ6/XoNsvzIxjSQV78O+vhR7vzIxjSTCxUe+AACAvzIxjSQyMY2lvhR7v8LFR74AAAAAr0F2v8LFR74V70M++Pdnv8LFR75KK8A+KcRQv8LFR74/fgs/hooxv8LFR76GijE/P34Lv8LFR74pxFA/SivAvsLFR77492c/Fe9DvsLFR76vQXY/rXqKpMLFR76+FHs/432YP8LFR76vQXY/0gqwP8LFR77492c/IL/FP8LFR74pxFA/Q8XYP8LFR76GijE/FGLoP8LFR74/fgs//PvzP8LFR75KK8A+2CD7P8LFR74V70M+X4r9P8LFR76tegol2CD7P8LFR74V70O+/PvzP8LFR75KK8C+FGLoP8LFR74/fgu/Q8XYP8LFR76GijG/IL/FP8LFR74pxFC/0gqwP8LFR77492e/432YP8LFR76vQXa/AACAP8LFR76+FHu/Fe9DvsLFR76vQXa/SivAvsLFR77492e/P34Lv8LFR74pxFC/hooxv8LFR76GijG/KcRQv8LFR74/fgu/+Pdnv8LFR75KK8C+r0F2v8LFR74V70O+vhR7v8LFR76teoqlXoNsvxXvw74AAAAA+PdnvxXvw77TkDg+eoJavxXvw77zBLU+TKdEvxXvw75RZgM/dT0nvxXvw751PSc/UWYDvxXvw75Mp0Q/8wS1vhXvw756glo/05A4vhXvw77492c/znGCpBXvw75eg2w/GhKXPxXvw77492c/PUGtPxXvw756glo/KLPBPxXvw75Mp0Q/up7TPxXvw751PSc/plPiPxXvw75RZgM/PUHtPxXvw77zBLU+/PvzPxXvw77TkDg+r0H2PxXvw77OcQIl/PvzPxXvw77TkDi+PUHtPxXvw77zBLW+plPiPxXvw75RZgO/up7TPxXvw751PSe/KLPBPxXvw75Mp0S/PUGtPxXvw756glq/GhKXPxXvw77492e/AACAPxXvw75eg2y/05A4vhXvw77492e/8wS1vhXvw756glq/UWYDvxXvw75Mp0S/dT0nvxXvw751PSe/TKdEvxXvw75RZgO/eoJavxXvw77zBLW++PdnvxXvw77TkDi+XoNsvxXvw77OcYKlMdtUv9o5Dr8AAAAAKcRQv9o5Dr/RGiY+TKdEv9o5Dr/B6aI+xfswv9o5Dr9eg+w+F4MWv9o5Dr8XgxY/XoPsvto5Dr/F+zA/wemivto5Dr9Mp0Q/0Romvto5Dr8pxFA/Q8tqpNo5Dr8x21Q/WsOUP9o5Dr8pxFA/cLqoP9o5Dr9Mp0Q/2CC7P9o5Dr/F+zA/jEHLP9o5Dr8XgxY/4n3YP9o5Dr9eg+w+plPiP9o5Dr/B6aI+FGLoP9o5Dr/RGiY+mG3qP9o5Dr9Dy+okFGLoP9o5Dr/RGia+plPiP9o5Dr/B6aK+4n3YP9o5Dr9eg+y+jEHLP9o5Dr8Xgxa/2CC7P9o5Dr/F+zC/cLqoP9o5Dr9Mp0S/WsOUP9o5Dr8pxFC/AACAP9o5Dr8x21S/0Romvto5Dr8pxFC/wemivto5Dr9Mp0S/XoPsvto5Dr/F+zC/F4MWv9o5Dr8Xgxa/xfswv9o5Dr9eg+y+TKdEv9o5Dr/B6aK+KcRQv9o5Dr/RGia+MdtUv9o5Dr9Dy2ql8wQ1v/MENb8AAAAAhooxv/MENb+vQg0+dT0nv/MENb/Ui4o+F4MWv/MENb9OI8k+AAAAv/MENb8AAAA/TiPJvvMENb8XgxY/1IuKvvMENb91PSc/r0INvvMENb+GijE/Bq1HpPMENb/zBDU/VqiRP/MENb+GijE/9aKiP/MENb91PSc/1EiyP/MENb8XgxY/AADAP/MENb8AAAA/jEHLP/MENb9OI8k+up7TP/MENb/Ui4o+Q8XYP/MENb+vQg0+eoLaP/MENb8GrcckQ8XYP/MENb+vQg2+up7TP/MENb/Ui4q+jEHLP/MENb9OI8m+AADAP/MENb8AAAC/1EiyP/MENb8Xgxa/9aKiP/MENb91PSe/VqiRP/MENb+GijG/AACAP/MENb/zBDW/r0INvvMENb+GijG/1IuKvvMENb91PSe/TiPJvvMENb8Xgxa/AAAAv/MENb8AAAC/F4MWv/MENb9OI8m+dT0nv/MENb/Ui4q+hooxv/MENb+vQg2+8wQ1v/MENb8GrUel2jkOvzHbVL8AAAAAP34LvzHbVL+t+d09UWYDvzHbVL/JtVk+XoPsvjHbVL91CJ4+TiPJvjHbVL9OI8k+dQievjHbVL9eg+w+ybVZvjHbVL9RZgM/rfndvTHbVL8/fgs/Y+IcpDHbVL/aOQ4/m9+NPzHbVL8/fgs/uTabPzHbVL9RZgM/HYKnPzHbVL9eg+w+1EiyPzHbVL9OI8k+2CC7PzHbVL91CJ4+KLPBPzHbVL/JtVk+IL/FPzHbVL+t+d097RzHPzHbVL9j4pwkIL/FPzHbVL+t+d29KLPBPzHbVL/JtVm+2CC7PzHbVL91CJ6+1EiyPzHbVL9OI8m+HYKnPzHbVL9eg+y+uTabPzHbVL9RZgO/m9+NPzHbVL8/fgu/AACAPzHbVL/aOQ6/rfndvTHbVL8/fgu/ybVZvjHbVL9RZgO/dQievjHbVL9eg+y+TiPJvjHbVL9OI8m+XoPsvjHbVL91CJ6+UWYDvzHbVL/JtVm+P34LvzHbVL+t+d292jkOvzHbVL9j4hylFe/Dvl6DbL8AAAAASivAvl6DbL815pg98wS1vl6DbL8a9hU+wemivl6DbL/JtVk+1IuKvl6DbL/Ui4o+ybVZvl6DbL/B6aI+GvYVvl6DbL/zBLU+NeaYvV6DbL9KK8A+qyDYo16DbL8V78M+Y46JP16DbL9KK8A+w76SP16DbL/zBLU+uTabP16DbL/B6aI+9aKiP16DbL/Ui4o+cLqoP16DbL/JtVk+PUGtP16DbL8a9hU+0gqwP16DbL815pg9xfuwP16DbL+rIFgk0gqwP16DbL815pi9PUGtP16DbL8a9hW+cLqoP16DbL/JtVm+9aKiP16DbL/Ui4q+uTabP16DbL/B6aK+w76SP16DbL/zBLW+Y46JP16DbL9KK8C+AACAP16DbL8V78O+NeaYvV6DbL9KK8C+GvYVvl6DbL/zBLW+ybVZvl6DbL/B6aK+1IuKvl6DbL/Ui4q+wemivl6DbL/JtVm+8wS1vl6DbL8a9hW+SivAvl6DbL815pi9Fe/Dvl6DbL+rINikwsVHvr4Ue78AAAAAFe9Dvr4Ue78M5Rs905A4vr4Ue7815pg90Romvr4Ue7+t+d09r0INvr4Ue7+vQg0+rfndvb4Ue7/RGiY+NeaYvb4Ue7/TkDg+DOUbvb4Ue78V70M+n1xco74Ue7/CxUc+KN+EP74Ue78V70M+Y46JP74Ue7/TkDg+m9+NP74Ue7/RGiY+VqiRP74Ue7+vQg0+WsOUP74Ue7+t+d09GhKXP74Ue7815pg9432YP74Ue78M5Rs9uPiYP74Ue7+fXNwj432YP74Ue78M5Ru9GhKXP74Ue7815pi9WsOUP74Ue7+t+d29VqiRP74Ue7+vQg2+m9+NP74Ue7/RGia+Y46JP74Ue7/TkDi+KN+EP74Ue78V70O+AACAP74Ue7/CxUe+DOUbvb4Ue78V70O+NeaYvb4Ue7/TkDi+rfndvb4Ue7/RGia+r0INvr4Ue7+vQg2+0Romvr4Ue7+t+d2905A4vr4Ue7815pi9Fe9Dvr4Ue78M5Ru9wsVHvr4Ue7+fXFykMjENpQAAgL8AAAAArXoKpQAAgL+fXNwjznECpQAAgL+rIFgkQ8vqpAAAgL9j4pwkBq3HpAAAgL8GrcckY+KcpAAAgL9Dy+okqyBYpAAAgL/OcQIln1zcowAAgL+tegoldL4bigAAgL8yMQ0lAACAPwAAgL+tegolAACAPwAAgL/OcQIlAACAPwAAgL9Dy+okAACAPwAAgL8GrcckAACAPwAAgL9j4pwkAACAPwAAgL+rIFgkAACAPwAAgL+fXNwjAACAPwAAgL90vpsKAACAPwAAgL+fXNyjAACAPwAAgL+rIFikAACAPwAAgL9j4pykAACAPwAAgL8GrcekAACAPwAAgL9Dy+qkAACAPwAAgL/OcQKlAACAPwAAgL+tegqlAACAPwAAgL8yMQ2ln1zcowAAgL+tegqlqyBYpAAAgL/OcQKlY+KcpAAAgL9Dy+qkBq3HpAAAgL8GrcekQ8vqpAAAgL9j4pykznECpQAAgL+rIFikrXoKpQAAgL+fXNyjMjENpQAAgL90vhuL",
-        "encoding": "base64",
-        "path": [
-         "array",
-         "buffer"
-        ]
-       }
-      ],
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "BufferAttributeModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "array": {
-        "buffer": {},
-        "dtype": "float32",
-        "shape": [
-         561,
-         3
-        ]
-       },
-       "version": 2
-      }
-     },
-     "a35f1d6394814350a868e004fa1d49be": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "RendererModel",
-      "state": {
-       "_height": 400,
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "_width": 600,
-       "camera": "IPY_MODEL_b59508c051144c62afe9a7900d564150",
-       "controls": [
-        "IPY_MODEL_f286fc575db846b0b3f72a03b0816c7a"
-       ],
-       "layout": "IPY_MODEL_377cf03634924f13847c7c218298b7c9",
-       "scene": "IPY_MODEL_ee84c55d35264bb19a9075e08343c745",
-       "shadowMap": "IPY_MODEL_2ef858e830df4234bcd1b05305e8eaf9"
-      }
-     },
-     "a7fa5488efef44cc86593927208bc6f8": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationActionModel",
-      "state": {
-       "_model_module": "jupyter-threejs",
-       "_model_module_version": "0.4.0",
-       "_model_name": "AnimationActionModel",
-       "_view_module_version": "0.4.0",
-       "clip": "IPY_MODEL_46dc4bc928c140c9b2157106d045b539",
-       "layout": "IPY_MODEL_3c92703508034441bf28382412ac2fe5",
-       "localRoot": "IPY_MODEL_cf7eef49fa254c968cc35664bb385f72",
-       "mixer": "IPY_MODEL_db86f27c27ec4c8e8d3e85c16193e5fb",
-       "repititions": "inf"
-      }
-     },
-     "aa8292a661004eb0aa5ab463dded6a62": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "ac8f136963914107b74da40a41ddd5a3": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "BufferGeometryModel",
-      "state": {
-       "_ref_geometry": "IPY_MODEL_f9c06b6ee4594ff4ba394822605ce1f1",
-       "_view_module": null,
-       "_view_module_version": "",
-       "attributes": {
-        "normal": "IPY_MODEL_46d49ebf-edb1-4066-95a6-3b798f34dc82",
-        "position": "IPY_MODEL_30fd684c-33b5-42bb-8fb0-b2735580d4ca",
-        "uv": "IPY_MODEL_996f8357-ecae-4c17-b429-27b1ef19b665"
-       },
-       "morphAttributes": {
-        "position": [
-         "IPY_MODEL_a127865d807f449aa2f54cdb2cd80b5b"
-        ]
-       },
-       "type": "BufferGeometry"
-      }
-     },
-     "b035c6b558db4d6c8f1d1d5d5ec3de97": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "SkeletonModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "bones": [
-        "IPY_MODEL_765ce8e93d564b0d984bf95de376ed29",
-        "IPY_MODEL_879eb5734d2449879b914dd56facfed0",
-        "IPY_MODEL_6a5ca85a20624e7fb0ab33c17207bccc"
-       ]
-      }
-     },
-     "b59508c051144c62afe9a7900d564150": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PerspectiveCameraModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "aspect": 1.5,
-       "position": [
-        10,
-        6,
-        10
-       ],
-       "projectionMatrix": [
-        1.4296712803397058,
-        0,
-        0,
-        0,
-        0,
-        2.1445069205095586,
-        0,
-        0,
-        0,
-        0,
-        -1.00010000500025,
-        -1,
-        0,
-        0,
-        -0.200010000500025,
-        0
-       ],
-       "type": "PerspectiveCamera"
-      }
-     },
-     "b62c30dabe05453c80996b80fd4f1aa4": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationMixerModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "rootObject": "IPY_MODEL_7d4b7c8ad9cd454499e2b4e6f814c316"
-      }
-     },
-     "bb383be0d09e42be9e0a9c1d13dcde3d": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "RendererModel",
-      "state": {
-       "_height": 400,
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "_width": 600,
-       "camera": "IPY_MODEL_cf16a07a48474bdbb5d94e346d149062",
-       "controls": [
-        "IPY_MODEL_4acda7189a3a4f6282b8d352cc72b5c8"
-       ],
-       "layout": "IPY_MODEL_f887a2c4ed9945cab5d196b9838d8b93",
-       "scene": "IPY_MODEL_7586b9bde0714d409c8736821df5aff3",
-       "shadowMap": "IPY_MODEL_6744d9394cfa4b79bcd76b176a91365d"
-      }
-     },
-     "beb875f49714431ca1d99e22d74a53c2": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationMixerModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "rootObject": "IPY_MODEL_40bc08d47f60411186632f40b42248b5"
-      }
-     },
-     "bfb4e453ce1844e18319bf97b1fc36c9": {
+     "083bf74e0bb14cc780c132c6f45fe369": {
       "buffers": [
        {
         "data": "AAAAAAAAAD8AAMA/AAAAQA==",
@@ -2276,21 +965,20 @@
        }
       ],
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "NumberKeyframeTrackModel",
       "state": {
        "_view_module": null,
        "_view_module_version": "",
-       "name": ".bones[1].rotation[z]",
+       "name": ".bones[1].rotation[x]",
        "times": {
-        "buffer": {},
         "dtype": "float32",
         "shape": [
          4
         ]
        },
+       "type": "Bone",
        "values": {
-        "buffer": {},
         "dtype": "float32",
         "shape": [
          4
@@ -2298,20 +986,559 @@
        }
       }
      },
-     "c041c44e665947fa9ed8a427a5a5abb8": {
+     "087e4843e5a74971b1520d088a7d56a4": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "ParametricGeometryModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "SceneModel",
       "state": {
        "_view_module": null,
        "_view_module_version": "",
-       "func": "\nfunction f(origu,origv) {\n    // scale u and v to the ranges I want: [0, 2*pi]\n    var u = 2*Math.PI*origu;\n    var v = 2*Math.PI*origv;\n    \n    var x = Math.sin(u);\n    var y = Math.cos(v);\n    var z = Math.cos(u+v);\n    \n    return new THREE.Vector3(x,y,z)\n}\n",
-       "slices": 16,
-       "stacks": 16,
-       "type": "ParametricGeometry"
+       "children": [
+        "IPY_MODEL_ba310b776b554a6f9991fea547d71563",
+        "IPY_MODEL_b84d09220c614f188eb059f6c60ce9eb",
+        "IPY_MODEL_482685a7d8564069ab800ecebd478b4d",
+        "IPY_MODEL_d3757a6356d0474dacdcab96327584c6",
+        "IPY_MODEL_3984926ff30c4a508e61c31f7fce94aa"
+       ],
+       "type": "Scene"
       }
      },
-     "c120390348ba4b319f14b132152ea0fa": {
+     "08ead024f1f44519b180cd3d38f8b379": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "MeshPhongMaterialModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "side": "DoubleSide",
+       "skinning": true,
+       "type": "MeshPhongMaterial"
+      }
+     },
+     "0b470d1a7047445585ed1d80e6314aed": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0d5faea4-8e36-4061-8194-ef284a0fcebe": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "OrthographicCameraModel",
+      "state": {
+       "bottom": -5,
+       "far": 500,
+       "left": -5,
+       "near": 0.5,
+       "projectionMatrix": [
+        0.2,
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0,
+        0,
+        0,
+        0,
+        -0.004004004004004004,
+        0,
+        0,
+        0,
+        -1.002002002002002,
+        1
+       ],
+       "right": 5,
+       "top": 5
+      }
+     },
+     "0e9ff5cfeed54a5ab771a553516b4388": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "SkeletonModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "bones": [
+        "IPY_MODEL_0304ecb4ed1143bcad346b55dcbec86e",
+        "IPY_MODEL_fe7d6be53ed14f83aefad6e22b36689b",
+        "IPY_MODEL_3364136f8f3946b3a687f479e6d395a9"
+       ]
+      }
+     },
+     "0ff90c0f2b364aa9b81a8b0ea5c37919": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationMixerModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "rootObject": "IPY_MODEL_7aeca132905345d6a6cc015626412b03"
+      }
+     },
+     "12eaad2aa913455282c722b2bfc216c0": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationMixerModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "rootObject": "IPY_MODEL_482685a7d8564069ab800ecebd478b4d"
+      }
+     },
+     "133c68c020cd46fdaee04cede79be04e": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "SceneModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "children": [
+        "IPY_MODEL_1699b6b842414fd2a3618d34b4d864e5",
+        "IPY_MODEL_d57ddb4b69ff4e8d83be86d273accb8e",
+        "IPY_MODEL_ca317ae15cd645c296683f3ddf31715b",
+        "IPY_MODEL_9511ad2b32104926993e6af18c04a38b"
+       ],
+       "type": "Scene"
+      }
+     },
+     "161ed1e8f9384df786bb06960c064b63": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "RendererModel",
+      "state": {
+       "_height": 400,
+       "_width": 600,
+       "camera": "IPY_MODEL_63363ddea1874caa82f7532623238abe",
+       "controls": [
+        "IPY_MODEL_9978ff90c29948e5ae61cd5f0073b541"
+       ],
+       "layout": "IPY_MODEL_59eda77c7c6b4de4b235a934c930d7b5",
+       "scene": "IPY_MODEL_7f383b17ed7e45cca88270e04d74aac7",
+       "shadowMap": "IPY_MODEL_7552aee94ae743b785e0610076368d04"
+      }
+     },
+     "1699b6b842414fd2a3618d34b4d864e5": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "GroupModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "children": [
+        "IPY_MODEL_4d41212879b24ba1a1fe72f62a1e5e97",
+        "IPY_MODEL_569b167f4d8d4a1a91e83efa537f24e9"
+       ],
+       "type": "Group"
+      }
+     },
+     "1ba7f975416e49a79587b3ef57cde0a6": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "OrbitControlsModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "controlling": "IPY_MODEL_482685a7d8564069ab800ecebd478b4d",
+       "maxAzimuthAngle": "inf",
+       "maxDistance": "inf",
+       "maxZoom": "inf",
+       "minAzimuthAngle": "-inf"
+      }
+     },
+     "1d248d02-d060-4124-b1fa-e3b49454c38f": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "OrthographicCameraModel",
+      "state": {
+       "bottom": -5,
+       "far": 500,
+       "left": -5,
+       "near": 0.5,
+       "projectionMatrix": [
+        0.2,
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0,
+        0,
+        0,
+        0,
+        -0.004004004004004004,
+        0,
+        0,
+        0,
+        -1.002002002002002,
+        1
+       ],
+       "right": 5,
+       "top": 5
+      }
+     },
+     "1db5d15e00c942c5ba917773100649c0": {
+      "buffers": [
+       {
+        "data": "AAAAAAEAAAA=",
+        "encoding": "base64",
+        "path": [
+         "times",
+         "buffer"
+        ]
+       },
+       {
+        "data": "AQAAAAAAAAAAAAAAAAAAAAAAAAABAAAA",
+        "encoding": "base64",
+        "path": [
+         "values",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "ColorKeyframeTrackModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "name": ".material.color",
+       "times": {
+        "dtype": "int32",
+        "shape": [
+         2
+        ]
+       },
+       "type": "Bone",
+       "values": {
+        "dtype": "int32",
+        "shape": [
+         6
+        ]
+       }
+      }
+     },
+     "1f35e04b-3777-401d-99d1-c9701ca6421a": {
+      "buffers": [
+       {
+        "data": "AAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAwsVHvr4Uez8AAAAAFe9Dvr4Uez8M5Rs905A4vr4Uez815pg90Romvr4Uez+t+d09r0INvr4Uez+vQg0+rfndvb4Uez/RGiY+NeaYvb4Uez/TkDg+DOUbvb4Uez8V70M+n1xco74Uez/CxUc+DOUbPb4Uez8V70M+NeaYPb4Uez/TkDg+rfndPb4Uez/RGiY+r0INPr4Uez+vQg0+0RomPr4Uez+t+d0905A4Pr4Uez815pg9Fe9DPr4Uez8M5Rs9wsVHPr4Uez+fXNwjFe9DPr4Uez8M5Ru905A4Pr4Uez815pi90RomPr4Uez+t+d29r0INPr4Uez+vQg2+rfndPb4Uez/RGia+NeaYPb4Uez/TkDi+DOUbPb4Uez8V70O+d0UlJL4Uez/CxUe+DOUbvb4Uez8V70O+NeaYvb4Uez/TkDi+rfndvb4Uez/RGia+r0INvr4Uez+vQg2+0Romvr4Uez+t+d2905A4vr4Uez815pi9Fe9Dvr4Uez8M5Ru9wsVHvr4Uez+fXFykFe/Dvl6DbD8AAAAASivAvl6DbD815pg98wS1vl6DbD8a9hU+wemivl6DbD/JtVk+1IuKvl6DbD/Ui4o+ybVZvl6DbD/B6aI+GvYVvl6DbD/zBLU+NeaYvV6DbD9KK8A+qyDYo16DbD8V78M+NeaYPV6DbD9KK8A+GvYVPl6DbD/zBLU+ybVZPl6DbD/B6aI+1IuKPl6DbD/Ui4o+wemiPl6DbD/JtVk+8wS1Pl6DbD8a9hU+SivAPl6DbD815pg9Fe/DPl6DbD+rIFgkSivAPl6DbD815pi98wS1Pl6DbD8a9hW+wemiPl6DbD/JtVm+1IuKPl6DbD/Ui4q+ybVZPl6DbD/B6aK+GvYVPl6DbD/zBLW+NeaYPV6DbD9KK8C+gBiiJF6DbD8V78O+NeaYvV6DbD9KK8C+GvYVvl6DbD/zBLW+ybVZvl6DbD/B6aK+1IuKvl6DbD/Ui4q+wemivl6DbD/JtVm+8wS1vl6DbD8a9hW+SivAvl6DbD815pi9Fe/Dvl6DbD+rINik2jkOvzHbVD8AAAAAP34LvzHbVD+t+d09UWYDvzHbVD/JtVk+XoPsvjHbVD91CJ4+TiPJvjHbVD9OI8k+dQievjHbVD9eg+w+ybVZvjHbVD9RZgM/rfndvTHbVD8/fgs/Y+IcpDHbVD/aOQ4/rfndPTHbVD8/fgs/ybVZPjHbVD9RZgM/dQiePjHbVD9eg+w+TiPJPjHbVD9OI8k+XoPsPjHbVD91CJ4+UWYDPzHbVD/JtVk+P34LPzHbVD+t+d092jkOPzHbVD9j4pwkP34LPzHbVD+t+d29UWYDPzHbVD/JtVm+XoPsPjHbVD91CJ6+TiPJPjHbVD9OI8m+dQiePjHbVD9eg+y+ybVZPjHbVD9RZgO/rfndPTHbVD8/fgu/lVPrJDHbVD/aOQ6/rfndvTHbVD8/fgu/ybVZvjHbVD9RZgO/dQievjHbVD9eg+y+TiPJvjHbVD9OI8m+XoPsvjHbVD91CJ6+UWYDvzHbVD/JtVm+P34LvzHbVD+t+d292jkOvzHbVD9j4hyl8wQ1v/MENT8AAAAAhooxv/MENT+vQg0+dT0nv/MENT/Ui4o+F4MWv/MENT9OI8k+AAAAv/MENT8AAAA/TiPJvvMENT8XgxY/1IuKvvMENT91PSc/r0INvvMENT+GijE/Bq1HpPMENT/zBDU/r0INPvMENT+GijE/1IuKPvMENT91PSc/TiPJPvMENT8XgxY/AAAAP/MENT8AAAA/F4MWP/MENT9OI8k+dT0nP/MENT/Ui4o+hooxP/MENT+vQg0+8wQ1P/MENT8GrcckhooxP/MENT+vQg2+dT0nP/MENT/Ui4q+F4MWP/MENT9OI8m+AAAAP/MENT8AAAC/TiPJPvMENT8Xgxa/1IuKPvMENT91PSe/r0INPvMENT+GijG/xMEVJfMENT/zBDW/r0INvvMENT+GijG/1IuKvvMENT91PSe/TiPJvvMENT8Xgxa/AAAAv/MENT8AAAC/F4MWv/MENT9OI8m+dT0nv/MENT/Ui4q+hooxv/MENT+vQg2+8wQ1v/MENT8GrUelMdtUv9o5Dj8AAAAAKcRQv9o5Dj/RGiY+TKdEv9o5Dj/B6aI+xfswv9o5Dj9eg+w+F4MWv9o5Dj8XgxY/XoPsvto5Dj/F+zA/wemivto5Dj9Mp0Q/0Romvto5Dj8pxFA/Q8tqpNo5Dj8x21Q/0RomPto5Dj8pxFA/wemiPto5Dj9Mp0Q/XoPsPto5Dj/F+zA/F4MWP9o5Dj8XgxY/xfswP9o5Dj9eg+w+TKdEP9o5Dj/B6aI+KcRQP9o5Dj/RGiY+MdtUP9o5Dj9Dy+okKcRQP9o5Dj/RGia+TKdEP9o5Dj/B6aK+xfswP9o5Dj9eg+y+F4MWP9o5Dj8Xgxa/XoPsPto5Dj/F+zC/wemiPto5Dj9Mp0S/0RomPto5Dj8pxFC/chgwJdo5Dj8x21S/0Romvto5Dj8pxFC/wemivto5Dj9Mp0S/XoPsvto5Dj/F+zC/F4MWv9o5Dj8Xgxa/xfswv9o5Dj9eg+y+TKdEv9o5Dj/B6aK+KcRQv9o5Dj/RGia+MdtUv9o5Dj9Dy2qlXoNsvxXvwz4AAAAA+PdnvxXvwz7TkDg+eoJavxXvwz7zBLU+TKdEvxXvwz5RZgM/dT0nvxXvwz51PSc/UWYDvxXvwz5Mp0Q/8wS1vhXvwz56glo/05A4vhXvwz7492c/znGCpBXvwz5eg2w/05A4PhXvwz7492c/8wS1PhXvwz56glo/UWYDPxXvwz5Mp0Q/dT0nPxXvwz51PSc/TKdEPxXvwz5RZgM/eoJaPxXvwz7zBLU++PdnPxXvwz7TkDg+XoNsPxXvwz7OcQIl+PdnPxXvwz7TkDi+eoJaPxXvwz7zBLW+TKdEPxXvwz5RZgO/dT0nPxXvwz51PSe/UWYDPxXvwz5Mp0S/8wS1PhXvwz56glq/05A4PhXvwz7492e/tapDJRXvwz5eg2y/05A4vhXvwz7492e/8wS1vhXvwz56glq/UWYDvxXvwz5Mp0S/dT0nvxXvwz51PSe/TKdEvxXvwz5RZgO/eoJavxXvwz7zBLW++PdnvxXvwz7TkDi+XoNsvxXvwz7OcYKlvhR7v8LFRz4AAAAAr0F2v8LFRz4V70M++Pdnv8LFRz5KK8A+KcRQv8LFRz4/fgs/hooxv8LFRz6GijE/P34Lv8LFRz4pxFA/SivAvsLFRz7492c/Fe9DvsLFRz6vQXY/rXqKpMLFRz6+FHs/Fe9DPsLFRz6vQXY/SivAPsLFRz7492c/P34LP8LFRz4pxFA/hooxP8LFRz6GijE/KcRQP8LFRz4/fgs/+PdnP8LFRz5KK8A+r0F2P8LFRz4V70M+vhR7P8LFRz6tegolr0F2P8LFRz4V70O++PdnP8LFRz5KK8C+KcRQP8LFRz4/fgu/hooxP8LFRz6GijG/P34LP8LFRz4pxFC/SivAPsLFRz7492e/Fe9DPsLFRz6vQXa/A7hPJcLFRz6+FHu/Fe9DvsLFRz6vQXa/SivAvsLFRz7492e/P34Lv8LFRz4pxFC/hooxv8LFRz6GijG/KcRQv8LFRz4/fgu/+Pdnv8LFRz5KK8C+r0F2v8LFRz4V70O+vhR7v8LFRz6teoqlAACAvzIxjSQAAAAAvhR7vzIxjSTCxUc+XoNsvzIxjSQV78M+MdtUvzIxjSTaOQ4/8wQ1vzIxjSTzBDU/2jkOvzIxjSQx21Q/Fe/DvjIxjSReg2w/wsVHvjIxjSS+FHs/MjGNpDIxjSQAAIA/wsVHPjIxjSS+FHs/Fe/DPjIxjSReg2w/2jkOPzIxjSQx21Q/8wQ1PzIxjSTzBDU/MdtUPzIxjSTaOQ4/XoNsPzIxjSQV78M+vhR7PzIxjSTCxUc+AACAPzIxjSQyMQ0lvhR7PzIxjSTCxUe+XoNsPzIxjSQV78O+MdtUPzIxjSTaOQ6/8wQ1PzIxjSTzBDW/2jkOPzIxjSQx21S/Fe/DPjIxjSReg2y/wsVHPjIxjSS+FHu/yslTJTIxjSQAAIC/wsVHvjIxjSS+FHu/Fe/DvjIxjSReg2y/2jkOvzIxjSQx21S/8wQ1vzIxjSTzBDW/MdtUvzIxjSTaOQ6/XoNsvzIxjSQV78O+vhR7vzIxjSTCxUe+AACAvzIxjSQyMY2lvhR7v8LFR74AAAAAr0F2v8LFR74V70M++Pdnv8LFR75KK8A+KcRQv8LFR74/fgs/hooxv8LFR76GijE/P34Lv8LFR74pxFA/SivAvsLFR77492c/Fe9DvsLFR76vQXY/rXqKpMLFR76+FHs/Fe9DPsLFR76vQXY/SivAPsLFR77492c/P34LP8LFR74pxFA/hooxP8LFR76GijE/KcRQP8LFR74/fgs/+PdnP8LFR75KK8A+r0F2P8LFR74V70M+vhR7P8LFR76tegolr0F2P8LFR74V70O++PdnP8LFR75KK8C+KcRQP8LFR74/fgu/hooxP8LFR76GijG/P34LP8LFR74pxFC/SivAPsLFR77492e/Fe9DPsLFR76vQXa/A7hPJcLFR76+FHu/Fe9DvsLFR76vQXa/SivAvsLFR77492e/P34Lv8LFR74pxFC/hooxv8LFR76GijG/KcRQv8LFR74/fgu/+Pdnv8LFR75KK8C+r0F2v8LFR74V70O+vhR7v8LFR76teoqlXoNsvxXvw74AAAAA+PdnvxXvw77TkDg+eoJavxXvw77zBLU+TKdEvxXvw75RZgM/dT0nvxXvw751PSc/UWYDvxXvw75Mp0Q/8wS1vhXvw756glo/05A4vhXvw77492c/znGCpBXvw75eg2w/05A4PhXvw77492c/8wS1PhXvw756glo/UWYDPxXvw75Mp0Q/dT0nPxXvw751PSc/TKdEPxXvw75RZgM/eoJaPxXvw77zBLU++PdnPxXvw77TkDg+XoNsPxXvw77OcQIl+PdnPxXvw77TkDi+eoJaPxXvw77zBLW+TKdEPxXvw75RZgO/dT0nPxXvw751PSe/UWYDPxXvw75Mp0S/8wS1PhXvw756glq/05A4PhXvw77492e/tapDJRXvw75eg2y/05A4vhXvw77492e/8wS1vhXvw756glq/UWYDvxXvw75Mp0S/dT0nvxXvw751PSe/TKdEvxXvw75RZgO/eoJavxXvw77zBLW++PdnvxXvw77TkDi+XoNsvxXvw77OcYKlMdtUv9o5Dr8AAAAAKcRQv9o5Dr/RGiY+TKdEv9o5Dr/B6aI+xfswv9o5Dr9eg+w+F4MWv9o5Dr8XgxY/XoPsvto5Dr/F+zA/wemivto5Dr9Mp0Q/0Romvto5Dr8pxFA/Q8tqpNo5Dr8x21Q/0RomPto5Dr8pxFA/wemiPto5Dr9Mp0Q/XoPsPto5Dr/F+zA/F4MWP9o5Dr8XgxY/xfswP9o5Dr9eg+w+TKdEP9o5Dr/B6aI+KcRQP9o5Dr/RGiY+MdtUP9o5Dr9Dy+okKcRQP9o5Dr/RGia+TKdEP9o5Dr/B6aK+xfswP9o5Dr9eg+y+F4MWP9o5Dr8Xgxa/XoPsPto5Dr/F+zC/wemiPto5Dr9Mp0S/0RomPto5Dr8pxFC/chgwJdo5Dr8x21S/0Romvto5Dr8pxFC/wemivto5Dr9Mp0S/XoPsvto5Dr/F+zC/F4MWv9o5Dr8Xgxa/xfswv9o5Dr9eg+y+TKdEv9o5Dr/B6aK+KcRQv9o5Dr/RGia+MdtUv9o5Dr9Dy2ql8wQ1v/MENb8AAAAAhooxv/MENb+vQg0+dT0nv/MENb/Ui4o+F4MWv/MENb9OI8k+AAAAv/MENb8AAAA/TiPJvvMENb8XgxY/1IuKvvMENb91PSc/r0INvvMENb+GijE/Bq1HpPMENb/zBDU/r0INPvMENb+GijE/1IuKPvMENb91PSc/TiPJPvMENb8XgxY/AAAAP/MENb8AAAA/F4MWP/MENb9OI8k+dT0nP/MENb/Ui4o+hooxP/MENb+vQg0+8wQ1P/MENb8GrcckhooxP/MENb+vQg2+dT0nP/MENb/Ui4q+F4MWP/MENb9OI8m+AAAAP/MENb8AAAC/TiPJPvMENb8Xgxa/1IuKPvMENb91PSe/r0INPvMENb+GijG/xMEVJfMENb/zBDW/r0INvvMENb+GijG/1IuKvvMENb91PSe/TiPJvvMENb8Xgxa/AAAAv/MENb8AAAC/F4MWv/MENb9OI8m+dT0nv/MENb/Ui4q+hooxv/MENb+vQg2+8wQ1v/MENb8GrUel2jkOvzHbVL8AAAAAP34LvzHbVL+t+d09UWYDvzHbVL/JtVk+XoPsvjHbVL91CJ4+TiPJvjHbVL9OI8k+dQievjHbVL9eg+w+ybVZvjHbVL9RZgM/rfndvTHbVL8/fgs/Y+IcpDHbVL/aOQ4/rfndPTHbVL8/fgs/ybVZPjHbVL9RZgM/dQiePjHbVL9eg+w+TiPJPjHbVL9OI8k+XoPsPjHbVL91CJ4+UWYDPzHbVL/JtVk+P34LPzHbVL+t+d092jkOPzHbVL9j4pwkP34LPzHbVL+t+d29UWYDPzHbVL/JtVm+XoPsPjHbVL91CJ6+TiPJPjHbVL9OI8m+dQiePjHbVL9eg+y+ybVZPjHbVL9RZgO/rfndPTHbVL8/fgu/lVPrJDHbVL/aOQ6/rfndvTHbVL8/fgu/ybVZvjHbVL9RZgO/dQievjHbVL9eg+y+TiPJvjHbVL9OI8m+XoPsvjHbVL91CJ6+UWYDvzHbVL/JtVm+P34LvzHbVL+t+d292jkOvzHbVL9j4hylFe/Dvl6DbL8AAAAASivAvl6DbL815pg98wS1vl6DbL8a9hU+wemivl6DbL/JtVk+1IuKvl6DbL/Ui4o+ybVZvl6DbL/B6aI+GvYVvl6DbL/zBLU+NeaYvV6DbL9KK8A+qyDYo16DbL8V78M+NeaYPV6DbL9KK8A+GvYVPl6DbL/zBLU+ybVZPl6DbL/B6aI+1IuKPl6DbL/Ui4o+wemiPl6DbL/JtVk+8wS1Pl6DbL8a9hU+SivAPl6DbL815pg9Fe/DPl6DbL+rIFgkSivAPl6DbL815pi98wS1Pl6DbL8a9hW+wemiPl6DbL/JtVm+1IuKPl6DbL/Ui4q+ybVZPl6DbL/B6aK+GvYVPl6DbL/zBLW+NeaYPV6DbL9KK8C+gBiiJF6DbL8V78O+NeaYvV6DbL9KK8C+GvYVvl6DbL/zBLW+ybVZvl6DbL/B6aK+1IuKvl6DbL/Ui4q+wemivl6DbL/JtVm+8wS1vl6DbL8a9hW+SivAvl6DbL815pi9Fe/Dvl6DbL+rINikwsVHvr4Ue78AAAAAFe9Dvr4Ue78M5Rs905A4vr4Ue7815pg90Romvr4Ue7+t+d09r0INvr4Ue7+vQg0+rfndvb4Ue7/RGiY+NeaYvb4Ue7/TkDg+DOUbvb4Ue78V70M+n1xco74Ue7/CxUc+DOUbPb4Ue78V70M+NeaYPb4Ue7/TkDg+rfndPb4Ue7/RGiY+r0INPr4Ue7+vQg0+0RomPr4Ue7+t+d0905A4Pr4Ue7815pg9Fe9DPr4Ue78M5Rs9wsVHPr4Ue7+fXNwjFe9DPr4Ue78M5Ru905A4Pr4Ue7815pi90RomPr4Ue7+t+d29r0INPr4Ue7+vQg2+rfndPb4Ue7/RGia+NeaYPb4Ue7/TkDi+DOUbPb4Ue78V70O+d0UlJL4Ue7/CxUe+DOUbvb4Ue78V70O+NeaYvb4Ue7/TkDi+rfndvb4Ue7/RGia+r0INvr4Ue7+vQg2+0Romvr4Ue7+t+d2905A4vr4Ue7815pi9Fe9Dvr4Ue78M5Ru9wsVHvr4Ue7+fXFykMjENpQAAgL8AAAAArXoKpQAAgL+fXNwjznECpQAAgL+rIFgkQ8vqpAAAgL9j4pwkBq3HpAAAgL8GrcckY+KcpAAAgL9Dy+okqyBYpAAAgL/OcQIln1zcowAAgL+tegoldL4bigAAgL8yMQ0ln1zcIwAAgL+tegolqyBYJAAAgL/OcQIlY+KcJAAAgL9Dy+okBq3HJAAAgL8GrcckQ8vqJAAAgL9j4pwkznECJQAAgL+rIFgkrXoKJQAAgL+fXNwjMjENJQAAgL90vpsKrXoKJQAAgL+fXNyjznECJQAAgL+rIFikQ8vqJAAAgL9j4pykBq3HJAAAgL8GrcekY+KcJAAAgL9Dy+qkqyBYJAAAgL/OcQKln1zcIwAAgL+tegqlrp3pCgAAgL8yMQ2ln1zcowAAgL+tegqlqyBYpAAAgL/OcQKlY+KcpAAAgL9Dy+qkBq3HpAAAgL8GrcekQ8vqpAAAgL9j4pykznECpQAAgL+rIFikrXoKpQAAgL+fXNyjMjENpQAAgL90vhuL",
+        "encoding": "base64",
+        "path": [
+         "array",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BufferAttributeModel",
+      "state": {
+       "array": {
+        "dtype": "float32",
+        "shape": [
+         561,
+         3
+        ]
+       },
+       "normalized": false,
+       "version": 0
+      }
+     },
+     "2efdd315b44341ad9ddc2ba8cda07079": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "2f876a8eec0a432ea2fc39dad67c5314": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "DirectionalLightModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "intensity": 0.6,
+       "matrixWorldNeedsUpdate": true,
+       "position": [
+        3,
+        5,
+        1
+       ],
+       "shadow": "IPY_MODEL_788a0da8-6af2-4c03-b17d-160e703f28ae",
+       "target": "IPY_MODEL_05e624ff-8139-4a39-bfc2-866842091a87",
+       "type": "DirectionalLight"
+      }
+     },
+     "303930afa87e4508b915e1610f5365e3": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationActionModel",
+      "state": {
+       "_model_module": "jupyter-threejs",
+       "_model_module_version": "1.0.0-beta.4",
+       "_model_name": "AnimationActionModel",
+       "_view_module_version": "1.0.0-beta.4",
+       "clip": "IPY_MODEL_73193216f64c43148db4c217aaec156c",
+       "layout": "IPY_MODEL_d73b3b15e93a4857846f4fd2a5b9f149",
+       "localRoot": "IPY_MODEL_7aeca132905345d6a6cc015626412b03",
+       "mixer": "IPY_MODEL_0ff90c0f2b364aa9b81a8b0ea5c37919",
+       "repititions": "inf"
+      }
+     },
+     "307263b8439a49f4842c6aa31b6bbbca": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "CylinderBufferGeometryModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "height": 50,
+       "heightSegments": 15,
+       "openEnded": true,
+       "radiusBottom": 5,
+       "radiusSegments": 5,
+       "radiusTop": 5,
+       "type": "CylinderBufferGeometry"
+      }
+     },
+     "3364136f8f3946b3a687f479e6d395a9": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BoneModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "position": [
+        0,
+        25,
+        0
+       ],
+       "type": "Bone"
+      }
+     },
+     "34969d8bc62a4767937e79e1822b1430": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "MeshModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "geometry": "IPY_MODEL_7a3e8ed3b0f04db5a936814848893eb1",
+       "material": "IPY_MODEL_a9c0a00b62c649eca0eec42e88b29b61"
+      }
+     },
+     "35466b0ac1744059885b1c63c97fad88": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "OrbitControlsModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "controlling": "IPY_MODEL_d57ddb4b69ff4e8d83be86d273accb8e",
+       "maxAzimuthAngle": "inf",
+       "maxDistance": "inf",
+       "maxZoom": "inf",
+       "minAzimuthAngle": "-inf"
+      }
+     },
+     "35e34a65ed8d413f930c9209fec1cda0": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "RendererModel",
+      "state": {
+       "_height": 400,
+       "_width": 600,
+       "camera": "IPY_MODEL_d57ddb4b69ff4e8d83be86d273accb8e",
+       "controls": [
+        "IPY_MODEL_35466b0ac1744059885b1c63c97fad88"
+       ],
+       "layout": "IPY_MODEL_b60f5c87c1b54db49a65d4a90e42edb4",
+       "scene": "IPY_MODEL_133c68c020cd46fdaee04cede79be04e",
+       "shadowMap": "IPY_MODEL_2efdd315b44341ad9ddc2ba8cda07079"
+      }
+     },
+     "3984926ff30c4a508e61c31f7fce94aa": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AmbientLightModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "type": "AmbientLight"
+      }
+     },
+     "3df6dd9231c949b287d49324dfa81a70": {
+      "buffers": [
+       {
+        "data": "AAAAAAAAAD8AAMA/AAAAQA==",
+        "encoding": "base64",
+        "path": [
+         "times",
+         "buffer"
+        ]
+       },
+       {
+        "data": "AAAAAJqZmT6amZm+AAAAAA==",
+        "encoding": "base64",
+        "path": [
+         "values",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "NumberKeyframeTrackModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "name": ".bones[1].rotation[z]",
+       "times": {
+        "dtype": "float32",
+        "shape": [
+         4
+        ]
+       },
+       "type": "Bone",
+       "values": {
+        "dtype": "float32",
+        "shape": [
+         4
+        ]
+       }
+      }
+     },
+     "423154fa-ae56-4877-9f91-54a3c67f0aa1": {
+      "buffers": [
+       {
+        "data": "AAAAAAAAgD/NzEw+AACAP83MzD4AAIA/mpkZPwAAgD/NzEw/AACAPwAAgD8AAIA/AAAAAO/ubj/NzEw+7+5uP83MzD7v7m4/mpkZP+/ubj/NzEw/7+5uPwAAgD/v7m4/AAAAAN7dXT/NzEw+3t1dP83MzD7e3V0/mpkZP97dXT/NzEw/3t1dPwAAgD/e3V0/AAAAAM3MTD/NzEw+zcxMP83MzD7NzEw/mpkZP83MTD/NzEw/zcxMPwAAgD/NzEw/AAAAALy7Oz/NzEw+vLs7P83MzD68uzs/mpkZP7y7Oz/NzEw/vLs7PwAAgD+8uzs/AAAAAKuqKj/NzEw+q6oqP83MzD6rqio/mpkZP6uqKj/NzEw/q6oqPwAAgD+rqio/AAAAAJqZGT/NzEw+mpkZP83MzD6amRk/mpkZP5qZGT/NzEw/mpkZPwAAgD+amRk/AAAAAImICD/NzEw+iYgIP83MzD6JiAg/mpkZP4mICD/NzEw/iYgIPwAAgD+JiAg/AAAAAO/u7j7NzEw+7+7uPs3MzD7v7u4+mpkZP+/u7j7NzEw/7+7uPgAAgD/v7u4+AAAAAM3MzD7NzEw+zczMPs3MzD7NzMw+mpkZP83MzD7NzEw/zczMPgAAgD/NzMw+AAAAAKuqqj7NzEw+q6qqPs3MzD6rqqo+mpkZP6uqqj7NzEw/q6qqPgAAgD+rqqo+AAAAAImIiD7NzEw+iYiIPs3MzD6JiIg+mpkZP4mIiD7NzEw/iYiIPgAAgD+JiIg+AAAAAM3MTD7NzEw+zcxMPs3MzD7NzEw+mpkZP83MTD7NzEw/zcxMPgAAgD/NzEw+AAAAAImICD7NzEw+iYgIPs3MzD6JiAg+mpkZP4mICD7NzEw/iYgIPgAAgD+JiAg+AAAAAImIiD3NzEw+iYiIPc3MzD6JiIg9mpkZP4mIiD3NzEw/iYiIPQAAgD+JiIg9AAAAAAAAAADNzEw+AAAAAM3MzD4AAAAAmpkZPwAAAADNzEw/AAAAAAAAgD8AAAAA",
+        "encoding": "base64",
+        "path": [
+         "array",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BufferAttributeModel",
+      "state": {
+       "array": {
+        "dtype": "float32",
+        "shape": [
+         96,
+         2
+        ]
+       },
+       "normalized": false,
+       "version": 0
+      }
+     },
+     "42ac08f0c37d4cb996ae7274a9fe9a02": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BoxBufferGeometryModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "type": "BoxBufferGeometry"
+      }
+     },
+     "44ed5613512348c6b814e9a155b81b90": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AmbientLightModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "intensity": 0.5,
+       "type": "AmbientLight"
+      }
+     },
+     "46b3539903de4d48b0845ff31db9c37d": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "47ed4691f03f4803920d786fcbacbedb": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationClipModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "duration": 5,
+       "tracks": [
+        "IPY_MODEL_fd06057c9cdd49b6a53d753db8730feb",
+        "IPY_MODEL_04f524ee1fff4e949f18831f62b60ee0"
+       ]
+      }
+     },
+     "482685a7d8564069ab800ecebd478b4d": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PerspectiveCameraModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "aspect": 1.5,
+       "position": [
+        10,
+        6,
+        10
+       ],
+       "projectionMatrix": [
+        1.4296712803397058,
+        0,
+        0,
+        0,
+        0,
+        2.1445069205095586,
+        0,
+        0,
+        0,
+        0,
+        -1.00010000500025,
+        -1,
+        0,
+        0,
+        -0.200010000500025,
+        0
+       ]
+      }
+     },
+     "4a77782b47ed4bb99e0af12b532a03cc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4d41212879b24ba1a1fe72f62a1e5e97": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "MeshModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "geometry": "IPY_MODEL_b43845c540da4a3bbb438c09111d1dc8",
+       "material": "IPY_MODEL_9a3660791d55462687b48eb07bf20ff6",
+       "morphTargetInfluences": []
+      }
+     },
+     "4d88177b29b547febd8f39a7a0f94855": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "501309c9ea6645d9bf31b668d3fb03b5": {
       "buffers": [
        {
         "data": "AAAAAAAAAD8AAMA/AAAAQA==",
@@ -2331,21 +1558,20 @@
        }
       ],
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "NumberKeyframeTrackModel",
       "state": {
        "_view_module": null,
        "_view_module_version": "",
        "name": ".bones[2].rotation[z]",
        "times": {
-        "buffer": {},
         "dtype": "float32",
         "shape": [
          4
         ]
        },
+       "type": "Bone",
        "values": {
-        "buffer": {},
         "dtype": "float32",
         "shape": [
          4
@@ -2353,34 +1579,46 @@
        }
       }
      },
-     "c197a398de0f42d7a3d77c6a3e5014e0": {
+     "5184d6151d6e428094d4befd90e683d0": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationActionModel",
-      "state": {
-       "_model_module": "jupyter-threejs",
-       "_model_module_version": "0.4.0",
-       "_model_name": "AnimationActionModel",
-       "_view_module_version": "0.4.0",
-       "clip": "IPY_MODEL_e14ce990009b4701ad95869182426d70",
-       "layout": "IPY_MODEL_aa8292a661004eb0aa5ab463dded6a62",
-       "localRoot": "IPY_MODEL_7d4b7c8ad9cd454499e2b4e6f814c316",
-       "mixer": "IPY_MODEL_b62c30dabe05453c80996b80fd4f1aa4",
-       "repititions": "inf"
-      }
-     },
-     "c34d72a5bef2409d84d8ac4b4edfbbff": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "DirectionalLightModel",
       "state": {
        "_view_module": null,
-       "_view_module_version": ""
+       "_view_module_version": "",
+       "intensity": 0.6,
+       "matrixWorldNeedsUpdate": true,
+       "position": [
+        3,
+        5,
+        1
+       ],
+       "shadow": "IPY_MODEL_de84ba1f-344d-4d39-bcfe-7c0e418f5ac5",
+       "target": "IPY_MODEL_bb88f78d-528d-4ddd-9c4f-3fd6e2f8912b",
+       "type": "DirectionalLight"
       }
      },
-     "cf16a07a48474bdbb5d94e346d149062": {
+     "55ceb7bfdb4f4d2c89bcb0ac03db8a18": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "569b167f4d8d4a1a91e83efa537f24e9": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "MeshModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "geometry": "IPY_MODEL_b43845c540da4a3bbb438c09111d1dc8",
+       "material": "IPY_MODEL_dbb4713aa5f84fa5bd17d8b52668f938",
+       "morphTargetInfluences": []
+      }
+     },
+     "57273feb5932436482db5fdb2fef14c1": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "PerspectiveCameraModel",
       "state": {
        "_view_module": null,
@@ -2408,288 +1646,88 @@
         0,
         -0.200010000500025,
         0
-       ],
-       "type": "PerspectiveCamera"
-      }
-     },
-     "cf7eef49fa254c968cc35664bb385f72": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "MeshModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "geometry": "IPY_MODEL_ac8f136963914107b74da40a41ddd5a3",
-       "material": "IPY_MODEL_f777551184ab43869680f3210b61ccee",
-       "type": "Mesh"
-      }
-     },
-     "d0c51440612745b2a66593eac869058b": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AmbientLightModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "intensity": 0.5,
-       "type": "AmbientLight"
-      }
-     },
-     "d0cfab19b453486986b8a4f7d00e201d": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "DirectionalLightModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "matrixWorldNeedsUpdate": true,
-       "position": [
-        0,
-        10,
-        10
-       ],
-       "shadow": "IPY_MODEL_d20b8a95-522b-4b1a-9384-4f29beb18664",
-       "target": "IPY_MODEL_50152692-311a-48a1-ba3d-a87b797d2d2a",
-       "type": "DirectionalLight"
-      }
-     },
-     "d107df5fdf58423194c0fcec9bc916ab": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationClipModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "duration": 5,
-       "tracks": [
-        "IPY_MODEL_6c31ee21ad86476bb751c99004ebce15",
-        "IPY_MODEL_81ad38301eff4ae499251bb76eda7db7"
        ]
       }
      },
-     "d1543a195888432c96a469ac5411437f": {
+     "58561ef05a0e49f18f5fa24c820d522f": {
       "buffers": [
        {
-        "data": "AAAAAAAAAD8AAMA/AAAAQA==",
+        "data": "AAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAwsVHvr4Uez8AAAAAFe9Dvr4Uez8M5Rs905A4vr4Uez815pg90Romvr4Uez+t+d09r0INvr4Uez+vQg0+rfndvb4Uez/RGiY+NeaYvb4Uez/TkDg+DOUbvb4Uez8V70M+n1xco74Uez/CxUc+KN+EP74Uez8V70M+Y46JP74Uez/TkDg+m9+NP74Uez/RGiY+VqiRP74Uez+vQg0+WsOUP74Uez+t+d09GhKXP74Uez815pg9432YP74Uez8M5Rs9uPiYP74Uez+fXNwj432YP74Uez8M5Ru9GhKXP74Uez815pi9WsOUP74Uez+t+d29VqiRP74Uez+vQg2+m9+NP74Uez/RGia+Y46JP74Uez/TkDi+KN+EP74Uez8V70O+AACAP74Uez/CxUe+DOUbvb4Uez8V70O+NeaYvb4Uez/TkDi+rfndvb4Uez/RGia+r0INvr4Uez+vQg2+0Romvr4Uez+t+d2905A4vr4Uez815pi9Fe9Dvr4Uez8M5Ru9wsVHvr4Uez+fXFykFe/Dvl6DbD8AAAAASivAvl6DbD815pg98wS1vl6DbD8a9hU+wemivl6DbD/JtVk+1IuKvl6DbD/Ui4o+ybVZvl6DbD/B6aI+GvYVvl6DbD/zBLU+NeaYvV6DbD9KK8A+qyDYo16DbD8V78M+Y46JP16DbD9KK8A+w76SP16DbD/zBLU+uTabP16DbD/B6aI+9aKiP16DbD/Ui4o+cLqoP16DbD/JtVk+PUGtP16DbD8a9hU+0gqwP16DbD815pg9xfuwP16DbD+rIFgk0gqwP16DbD815pi9PUGtP16DbD8a9hW+cLqoP16DbD/JtVm+9aKiP16DbD/Ui4q+uTabP16DbD/B6aK+w76SP16DbD/zBLW+Y46JP16DbD9KK8C+AACAP16DbD8V78O+NeaYvV6DbD9KK8C+GvYVvl6DbD/zBLW+ybVZvl6DbD/B6aK+1IuKvl6DbD/Ui4q+wemivl6DbD/JtVm+8wS1vl6DbD8a9hW+SivAvl6DbD815pi9Fe/Dvl6DbD+rINik2jkOvzHbVD8AAAAAP34LvzHbVD+t+d09UWYDvzHbVD/JtVk+XoPsvjHbVD91CJ4+TiPJvjHbVD9OI8k+dQievjHbVD9eg+w+ybVZvjHbVD9RZgM/rfndvTHbVD8/fgs/Y+IcpDHbVD/aOQ4/m9+NPzHbVD8/fgs/uTabPzHbVD9RZgM/HYKnPzHbVD9eg+w+1EiyPzHbVD9OI8k+2CC7PzHbVD91CJ4+KLPBPzHbVD/JtVk+IL/FPzHbVD+t+d097RzHPzHbVD9j4pwkIL/FPzHbVD+t+d29KLPBPzHbVD/JtVm+2CC7PzHbVD91CJ6+1EiyPzHbVD9OI8m+HYKnPzHbVD9eg+y+uTabPzHbVD9RZgO/m9+NPzHbVD8/fgu/AACAPzHbVD/aOQ6/rfndvTHbVD8/fgu/ybVZvjHbVD9RZgO/dQievjHbVD9eg+y+TiPJvjHbVD9OI8m+XoPsvjHbVD91CJ6+UWYDvzHbVD/JtVm+P34LvzHbVD+t+d292jkOvzHbVD9j4hyl8wQ1v/MENT8AAAAAhooxv/MENT+vQg0+dT0nv/MENT/Ui4o+F4MWv/MENT9OI8k+AAAAv/MENT8AAAA/TiPJvvMENT8XgxY/1IuKvvMENT91PSc/r0INvvMENT+GijE/Bq1HpPMENT/zBDU/VqiRP/MENT+GijE/9aKiP/MENT91PSc/1EiyP/MENT8XgxY/AADAP/MENT8AAAA/jEHLP/MENT9OI8k+up7TP/MENT/Ui4o+Q8XYP/MENT+vQg0+eoLaP/MENT8GrcckQ8XYP/MENT+vQg2+up7TP/MENT/Ui4q+jEHLP/MENT9OI8m+AADAP/MENT8AAAC/1EiyP/MENT8Xgxa/9aKiP/MENT91PSe/VqiRP/MENT+GijG/AACAP/MENT/zBDW/r0INvvMENT+GijG/1IuKvvMENT91PSe/TiPJvvMENT8Xgxa/AAAAv/MENT8AAAC/F4MWv/MENT9OI8m+dT0nv/MENT/Ui4q+hooxv/MENT+vQg2+8wQ1v/MENT8GrUelMdtUv9o5Dj8AAAAAKcRQv9o5Dj/RGiY+TKdEv9o5Dj/B6aI+xfswv9o5Dj9eg+w+F4MWv9o5Dj8XgxY/XoPsvto5Dj/F+zA/wemivto5Dj9Mp0Q/0Romvto5Dj8pxFA/Q8tqpNo5Dj8x21Q/WsOUP9o5Dj8pxFA/cLqoP9o5Dj9Mp0Q/2CC7P9o5Dj/F+zA/jEHLP9o5Dj8XgxY/4n3YP9o5Dj9eg+w+plPiP9o5Dj/B6aI+FGLoP9o5Dj/RGiY+mG3qP9o5Dj9Dy+okFGLoP9o5Dj/RGia+plPiP9o5Dj/B6aK+4n3YP9o5Dj9eg+y+jEHLP9o5Dj8Xgxa/2CC7P9o5Dj/F+zC/cLqoP9o5Dj9Mp0S/WsOUP9o5Dj8pxFC/AACAP9o5Dj8x21S/0Romvto5Dj8pxFC/wemivto5Dj9Mp0S/XoPsvto5Dj/F+zC/F4MWv9o5Dj8Xgxa/xfswv9o5Dj9eg+y+TKdEv9o5Dj/B6aK+KcRQv9o5Dj/RGia+MdtUv9o5Dj9Dy2qlXoNsvxXvwz4AAAAA+PdnvxXvwz7TkDg+eoJavxXvwz7zBLU+TKdEvxXvwz5RZgM/dT0nvxXvwz51PSc/UWYDvxXvwz5Mp0Q/8wS1vhXvwz56glo/05A4vhXvwz7492c/znGCpBXvwz5eg2w/GhKXPxXvwz7492c/PUGtPxXvwz56glo/KLPBPxXvwz5Mp0Q/up7TPxXvwz51PSc/plPiPxXvwz5RZgM/PUHtPxXvwz7zBLU+/PvzPxXvwz7TkDg+r0H2PxXvwz7OcQIl/PvzPxXvwz7TkDi+PUHtPxXvwz7zBLW+plPiPxXvwz5RZgO/up7TPxXvwz51PSe/KLPBPxXvwz5Mp0S/PUGtPxXvwz56glq/GhKXPxXvwz7492e/AACAPxXvwz5eg2y/05A4vhXvwz7492e/8wS1vhXvwz56glq/UWYDvxXvwz5Mp0S/dT0nvxXvwz51PSe/TKdEvxXvwz5RZgO/eoJavxXvwz7zBLW++PdnvxXvwz7TkDi+XoNsvxXvwz7OcYKlvhR7v8LFRz4AAAAAr0F2v8LFRz4V70M++Pdnv8LFRz5KK8A+KcRQv8LFRz4/fgs/hooxv8LFRz6GijE/P34Lv8LFRz4pxFA/SivAvsLFRz7492c/Fe9DvsLFRz6vQXY/rXqKpMLFRz6+FHs/432YP8LFRz6vQXY/0gqwP8LFRz7492c/IL/FP8LFRz4pxFA/Q8XYP8LFRz6GijE/FGLoP8LFRz4/fgs//PvzP8LFRz5KK8A+2CD7P8LFRz4V70M+X4r9P8LFRz6tegol2CD7P8LFRz4V70O+/PvzP8LFRz5KK8C+FGLoP8LFRz4/fgu/Q8XYP8LFRz6GijG/IL/FP8LFRz4pxFC/0gqwP8LFRz7492e/432YP8LFRz6vQXa/AACAP8LFRz6+FHu/Fe9DvsLFRz6vQXa/SivAvsLFRz7492e/P34Lv8LFRz4pxFC/hooxv8LFRz6GijG/KcRQv8LFRz4/fgu/+Pdnv8LFRz5KK8C+r0F2v8LFRz4V70O+vhR7v8LFRz6teoqlAACAvzIxjSQAAAAAvhR7vzIxjSTCxUc+XoNsvzIxjSQV78M+MdtUvzIxjSTaOQ4/8wQ1vzIxjSTzBDU/2jkOvzIxjSQx21Q/Fe/DvjIxjSReg2w/wsVHvjIxjSS+FHs/MjGNpDIxjSQAAIA/uPiYPzIxjSS+FHs/xfuwPzIxjSReg2w/7RzHPzIxjSQx21Q/eoLaPzIxjSTzBDU/mG3qPzIxjSTaOQ4/r0H2PzIxjSQV78M+X4r9PzIxjSTCxUc+AAAAQDIxjSQyMQ0lX4r9PzIxjSTCxUe+r0H2PzIxjSQV78O+mG3qPzIxjSTaOQ6/eoLaPzIxjSTzBDW/7RzHPzIxjSQx21S/xfuwPzIxjSReg2y/uPiYPzIxjSS+FHu/AACAPzIxjSQAAIC/wsVHvjIxjSS+FHu/Fe/DvjIxjSReg2y/2jkOvzIxjSQx21S/8wQ1vzIxjSTzBDW/MdtUvzIxjSTaOQ6/XoNsvzIxjSQV78O+vhR7vzIxjSTCxUe+AACAvzIxjSQyMY2lvhR7v8LFR74AAAAAr0F2v8LFR74V70M++Pdnv8LFR75KK8A+KcRQv8LFR74/fgs/hooxv8LFR76GijE/P34Lv8LFR74pxFA/SivAvsLFR77492c/Fe9DvsLFR76vQXY/rXqKpMLFR76+FHs/432YP8LFR76vQXY/0gqwP8LFR77492c/IL/FP8LFR74pxFA/Q8XYP8LFR76GijE/FGLoP8LFR74/fgs//PvzP8LFR75KK8A+2CD7P8LFR74V70M+X4r9P8LFR76tegol2CD7P8LFR74V70O+/PvzP8LFR75KK8C+FGLoP8LFR74/fgu/Q8XYP8LFR76GijG/IL/FP8LFR74pxFC/0gqwP8LFR77492e/432YP8LFR76vQXa/AACAP8LFR76+FHu/Fe9DvsLFR76vQXa/SivAvsLFR77492e/P34Lv8LFR74pxFC/hooxv8LFR76GijG/KcRQv8LFR74/fgu/+Pdnv8LFR75KK8C+r0F2v8LFR74V70O+vhR7v8LFR76teoqlXoNsvxXvw74AAAAA+PdnvxXvw77TkDg+eoJavxXvw77zBLU+TKdEvxXvw75RZgM/dT0nvxXvw751PSc/UWYDvxXvw75Mp0Q/8wS1vhXvw756glo/05A4vhXvw77492c/znGCpBXvw75eg2w/GhKXPxXvw77492c/PUGtPxXvw756glo/KLPBPxXvw75Mp0Q/up7TPxXvw751PSc/plPiPxXvw75RZgM/PUHtPxXvw77zBLU+/PvzPxXvw77TkDg+r0H2PxXvw77OcQIl/PvzPxXvw77TkDi+PUHtPxXvw77zBLW+plPiPxXvw75RZgO/up7TPxXvw751PSe/KLPBPxXvw75Mp0S/PUGtPxXvw756glq/GhKXPxXvw77492e/AACAPxXvw75eg2y/05A4vhXvw77492e/8wS1vhXvw756glq/UWYDvxXvw75Mp0S/dT0nvxXvw751PSe/TKdEvxXvw75RZgO/eoJavxXvw77zBLW++PdnvxXvw77TkDi+XoNsvxXvw77OcYKlMdtUv9o5Dr8AAAAAKcRQv9o5Dr/RGiY+TKdEv9o5Dr/B6aI+xfswv9o5Dr9eg+w+F4MWv9o5Dr8XgxY/XoPsvto5Dr/F+zA/wemivto5Dr9Mp0Q/0Romvto5Dr8pxFA/Q8tqpNo5Dr8x21Q/WsOUP9o5Dr8pxFA/cLqoP9o5Dr9Mp0Q/2CC7P9o5Dr/F+zA/jEHLP9o5Dr8XgxY/4n3YP9o5Dr9eg+w+plPiP9o5Dr/B6aI+FGLoP9o5Dr/RGiY+mG3qP9o5Dr9Dy+okFGLoP9o5Dr/RGia+plPiP9o5Dr/B6aK+4n3YP9o5Dr9eg+y+jEHLP9o5Dr8Xgxa/2CC7P9o5Dr/F+zC/cLqoP9o5Dr9Mp0S/WsOUP9o5Dr8pxFC/AACAP9o5Dr8x21S/0Romvto5Dr8pxFC/wemivto5Dr9Mp0S/XoPsvto5Dr/F+zC/F4MWv9o5Dr8Xgxa/xfswv9o5Dr9eg+y+TKdEv9o5Dr/B6aK+KcRQv9o5Dr/RGia+MdtUv9o5Dr9Dy2ql8wQ1v/MENb8AAAAAhooxv/MENb+vQg0+dT0nv/MENb/Ui4o+F4MWv/MENb9OI8k+AAAAv/MENb8AAAA/TiPJvvMENb8XgxY/1IuKvvMENb91PSc/r0INvvMENb+GijE/Bq1HpPMENb/zBDU/VqiRP/MENb+GijE/9aKiP/MENb91PSc/1EiyP/MENb8XgxY/AADAP/MENb8AAAA/jEHLP/MENb9OI8k+up7TP/MENb/Ui4o+Q8XYP/MENb+vQg0+eoLaP/MENb8GrcckQ8XYP/MENb+vQg2+up7TP/MENb/Ui4q+jEHLP/MENb9OI8m+AADAP/MENb8AAAC/1EiyP/MENb8Xgxa/9aKiP/MENb91PSe/VqiRP/MENb+GijG/AACAP/MENb/zBDW/r0INvvMENb+GijG/1IuKvvMENb91PSe/TiPJvvMENb8Xgxa/AAAAv/MENb8AAAC/F4MWv/MENb9OI8m+dT0nv/MENb/Ui4q+hooxv/MENb+vQg2+8wQ1v/MENb8GrUel2jkOvzHbVL8AAAAAP34LvzHbVL+t+d09UWYDvzHbVL/JtVk+XoPsvjHbVL91CJ4+TiPJvjHbVL9OI8k+dQievjHbVL9eg+w+ybVZvjHbVL9RZgM/rfndvTHbVL8/fgs/Y+IcpDHbVL/aOQ4/m9+NPzHbVL8/fgs/uTabPzHbVL9RZgM/HYKnPzHbVL9eg+w+1EiyPzHbVL9OI8k+2CC7PzHbVL91CJ4+KLPBPzHbVL/JtVk+IL/FPzHbVL+t+d097RzHPzHbVL9j4pwkIL/FPzHbVL+t+d29KLPBPzHbVL/JtVm+2CC7PzHbVL91CJ6+1EiyPzHbVL9OI8m+HYKnPzHbVL9eg+y+uTabPzHbVL9RZgO/m9+NPzHbVL8/fgu/AACAPzHbVL/aOQ6/rfndvTHbVL8/fgu/ybVZvjHbVL9RZgO/dQievjHbVL9eg+y+TiPJvjHbVL9OI8m+XoPsvjHbVL91CJ6+UWYDvzHbVL/JtVm+P34LvzHbVL+t+d292jkOvzHbVL9j4hylFe/Dvl6DbL8AAAAASivAvl6DbL815pg98wS1vl6DbL8a9hU+wemivl6DbL/JtVk+1IuKvl6DbL/Ui4o+ybVZvl6DbL/B6aI+GvYVvl6DbL/zBLU+NeaYvV6DbL9KK8A+qyDYo16DbL8V78M+Y46JP16DbL9KK8A+w76SP16DbL/zBLU+uTabP16DbL/B6aI+9aKiP16DbL/Ui4o+cLqoP16DbL/JtVk+PUGtP16DbL8a9hU+0gqwP16DbL815pg9xfuwP16DbL+rIFgk0gqwP16DbL815pi9PUGtP16DbL8a9hW+cLqoP16DbL/JtVm+9aKiP16DbL/Ui4q+uTabP16DbL/B6aK+w76SP16DbL/zBLW+Y46JP16DbL9KK8C+AACAP16DbL8V78O+NeaYvV6DbL9KK8C+GvYVvl6DbL/zBLW+ybVZvl6DbL/B6aK+1IuKvl6DbL/Ui4q+wemivl6DbL/JtVm+8wS1vl6DbL8a9hW+SivAvl6DbL815pi9Fe/Dvl6DbL+rINikwsVHvr4Ue78AAAAAFe9Dvr4Ue78M5Rs905A4vr4Ue7815pg90Romvr4Ue7+t+d09r0INvr4Ue7+vQg0+rfndvb4Ue7/RGiY+NeaYvb4Ue7/TkDg+DOUbvb4Ue78V70M+n1xco74Ue7/CxUc+KN+EP74Ue78V70M+Y46JP74Ue7/TkDg+m9+NP74Ue7/RGiY+VqiRP74Ue7+vQg0+WsOUP74Ue7+t+d09GhKXP74Ue7815pg9432YP74Ue78M5Rs9uPiYP74Ue7+fXNwj432YP74Ue78M5Ru9GhKXP74Ue7815pi9WsOUP74Ue7+t+d29VqiRP74Ue7+vQg2+m9+NP74Ue7/RGia+Y46JP74Ue7/TkDi+KN+EP74Ue78V70O+AACAP74Ue7/CxUe+DOUbvb4Ue78V70O+NeaYvb4Ue7/TkDi+rfndvb4Ue7/RGia+r0INvr4Ue7+vQg2+0Romvr4Ue7+t+d2905A4vr4Ue7815pi9Fe9Dvr4Ue78M5Ru9wsVHvr4Ue7+fXFykMjENpQAAgL8AAAAArXoKpQAAgL+fXNwjznECpQAAgL+rIFgkQ8vqpAAAgL9j4pwkBq3HpAAAgL8GrcckY+KcpAAAgL9Dy+okqyBYpAAAgL/OcQIln1zcowAAgL+tegoldL4bigAAgL8yMQ0lAACAPwAAgL+tegolAACAPwAAgL/OcQIlAACAPwAAgL9Dy+okAACAPwAAgL8GrcckAACAPwAAgL9j4pwkAACAPwAAgL+rIFgkAACAPwAAgL+fXNwjAACAPwAAgL90vpsKAACAPwAAgL+fXNyjAACAPwAAgL+rIFikAACAPwAAgL9j4pykAACAPwAAgL8GrcekAACAPwAAgL9Dy+qkAACAPwAAgL/OcQKlAACAPwAAgL+tegqlAACAPwAAgL8yMQ2ln1zcowAAgL+tegqlqyBYpAAAgL/OcQKlY+KcpAAAgL9Dy+qkBq3HpAAAgL8GrcekQ8vqpAAAgL9j4pykznECpQAAgL+rIFikrXoKpQAAgL+fXNyjMjENpQAAgL90vhuL",
         "encoding": "base64",
         "path": [
-         "times",
-         "buffer"
-        ]
-       },
-       {
-        "data": "AAAAADMzMz8zMzO/AAAAAA==",
-        "encoding": "base64",
-        "path": [
-         "values",
+         "array",
          "buffer"
         ]
        }
       ],
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "NumberKeyframeTrackModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BufferAttributeModel",
       "state": {
        "_view_module": null,
        "_view_module_version": "",
-       "name": ".bones[2].rotation[y]",
-       "times": {
-        "buffer": {},
+       "array": {
         "dtype": "float32",
         "shape": [
-         4
+         561,
+         3
         ]
        },
-       "values": {
-        "buffer": {},
-        "dtype": "float32",
-        "shape": [
-         4
-        ]
-       }
+       "version": 2
       }
      },
-     "d20b8a95-522b-4b1a-9384-4f29beb18664": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "DirectionalLightShadowModel",
-      "state": {
-       "camera": "IPY_MODEL_058e735c-2504-4214-aa55-1459cdf8f4d2"
-      }
-     },
-     "d280682347b74486be3601ae937c1883": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationMixerModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "rootObject": "IPY_MODEL_96d31bd0f71b474b9950367ad61d4a9d"
-      }
-     },
-     "d71a1a561a4f449c9949369d77bad859": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationActionModel",
-      "state": {
-       "_model_module": "jupyter-threejs",
-       "_model_module_version": "0.4.0",
-       "_model_name": "AnimationActionModel",
-       "_view_module_version": "0.4.0",
-       "clip": "IPY_MODEL_45bac4cd84f243489f3fce05c49fd8eb",
-       "layout": "IPY_MODEL_41045c4aa130473191016ccbf764a051",
-       "localRoot": "IPY_MODEL_41ca13be3d034bb78c5315b6cc84fadd",
-       "mixer": "IPY_MODEL_23bce2b9a9824dae8391240e9fbd185a",
-       "repititions": "inf"
-      }
-     },
-     "db86f27c27ec4c8e8d3e85c16193e5fb": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationMixerModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "rootObject": "IPY_MODEL_cf7eef49fa254c968cc35664bb385f72"
-      }
-     },
-     "e14ce990009b4701ad95869182426d70": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationClipModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "duration": 2,
-       "tracks": [
-        "IPY_MODEL_ffe103fe39344bb4bc4b4c7cf5ed0d90",
-        "IPY_MODEL_d1543a195888432c96a469ac5411437f"
-       ]
-      }
-     },
-     "e78c9e4fb3244ba4aa981bf687466cf3": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "AnimationActionModel",
-      "state": {
-       "_model_module": "jupyter-threejs",
-       "_model_module_version": "0.4.0",
-       "_model_name": "AnimationActionModel",
-       "_view_module_version": "0.4.0",
-       "clip": "IPY_MODEL_56457e19a7684decb50af664d17dc999",
-       "layout": "IPY_MODEL_f26695e359c7477699625b21cf598f30",
-       "localRoot": "IPY_MODEL_7d4b7c8ad9cd454499e2b4e6f814c316",
-       "mixer": "IPY_MODEL_5ca0b95203774d8ca9f3febbda13f4d7",
-       "repititions": "inf"
-      }
-     },
-     "ea5350a92d634e5f9be6939b0d9b3d16": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "DirectionalLightModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "intensity": 0.6,
-       "matrixWorldNeedsUpdate": true,
-       "position": [
-        3,
-        5,
-        1
-       ],
-       "shadow": "IPY_MODEL_54924996-dc91-485a-bfab-d74b7a231bc4",
-       "target": "IPY_MODEL_448c47c1-4b22-444a-956f-3d21c3cfd450",
-       "type": "DirectionalLight"
-      }
-     },
-     "ee84c55d35264bb19a9075e08343c745": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "SceneModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "children": [
-        "IPY_MODEL_41ca13be3d034bb78c5315b6cc84fadd",
-        "IPY_MODEL_b59508c051144c62afe9a7900d564150",
-        "IPY_MODEL_ea5350a92d634e5f9be6939b0d9b3d16",
-        "IPY_MODEL_275c26b9f02d424c97e7d2bcfd241c81"
-       ],
-       "type": "Scene"
-      }
-     },
-     "ef32ce4223e44d84b93e045f75be7483": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "SceneModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "children": [
-        "IPY_MODEL_40bc08d47f60411186632f40b42248b5",
-        "IPY_MODEL_6379f3052dcd4a5d85bc5fd1d4c83e4a",
-        "IPY_MODEL_96d31bd0f71b474b9950367ad61d4a9d",
-        "IPY_MODEL_d0cfab19b453486986b8a4f7d00e201d",
-        "IPY_MODEL_9b221fa874364a28b5dd6d8a99894596"
-       ],
-       "type": "Scene"
-      }
-     },
-     "f26695e359c7477699625b21cf598f30": {
+     "59eda77c7c6b4de4b235a934c930d7b5": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.0.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "f286fc575db846b0b3f72a03b0816c7a": {
+     "5d1449648af748ad8347e0ef7d69cfe1": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "OrbitControlsModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "controlling": "IPY_MODEL_b59508c051144c62afe9a7900d564150",
-       "maxAzimuthAngle": "inf",
-       "maxDistance": "inf",
-       "maxZoom": "inf",
-       "minAzimuthAngle": "-inf"
-      }
-     },
-     "f777551184ab43869680f3210b61ccee": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "MeshPhongMaterialModel",
-      "state": {
-       "_view_module": null,
-       "_view_module_version": "",
-       "color": "#ff3333",
-       "morphTargets": true,
-       "shininess": 150,
-       "type": "MeshPhongMaterial"
-      }
-     },
-     "f887a2c4ed9945cab5d196b9838d8b93": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "f9c06b6ee4594ff4ba394822605ce1f1": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "SphereBufferGeometryModel",
       "state": {
        "_view_module": null,
        "_view_module_version": "",
        "heightSegments": 16,
-       "radius": 1,
        "type": "SphereBufferGeometry",
        "widthSegments": 32
       }
      },
-     "f9c4682a3f104f8da8791d52b4ba43b0": {
+     "5e3aa4f7-79fb-45c6-9ea3-219c55baf85c": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "OrthographicCameraModel",
+      "state": {
+       "bottom": -5,
+       "far": 500,
+       "left": -5,
+       "near": 0.5,
+       "projectionMatrix": [
+        0.2,
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0,
+        0,
+        0,
+        0,
+        -0.004004004004004004,
+        0,
+        0,
+        0,
+        -1.002002002002002,
+        1
+       ],
+       "right": 5,
+       "top": 5
+      }
+     },
+     "63363ddea1874caa82f7532623238abe": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "PerspectiveCameraModel",
       "state": {
        "_view_module": null,
@@ -2717,30 +1755,155 @@
         0,
         -0.200010000500025,
         0
-       ],
-       "type": "PerspectiveCamera"
+       ]
       }
      },
-     "f9f842841acc413287cb13f3592b5445": {
+     "665aa037e4ab4a70be1e368c19c7a18b": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "DirectionalLightModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationActionModel",
+      "state": {
+       "_model_module": "jupyter-threejs",
+       "_model_module_version": "1.0.0-beta.4",
+       "_model_name": "AnimationActionModel",
+       "_view_module_version": "1.0.0-beta.4",
+       "clip": "IPY_MODEL_81a1c3daabc5401c8e37654eca74a26e",
+       "layout": "IPY_MODEL_55ceb7bfdb4f4d2c89bcb0ac03db8a18",
+       "localRoot": "IPY_MODEL_7aeca132905345d6a6cc015626412b03",
+       "mixer": "IPY_MODEL_bf34a5bef01f45cd8109e959e9ac5ce3",
+       "repititions": "inf"
+      }
+     },
+     "672aa4c0-36d8-4758-a007-63ac41274743": {
+      "buffers": [
+       {
+        "data": "AAAAAAAAyEEAAKBARiuYQAAAyEFYxcU/Xhc8QAAAyEFWcYHAXhc8wAAAyEFWcYHARiuYwAAAyEFYxcU/fn2wpgAAyEEAAKBAAAAAAFVVrUEAAKBARiuYQFVVrUFYxcU/Xhc8QFVVrUFWcYHAXhc8wFVVrUFWcYHARiuYwFVVrUFYxcU/fn2wplVVrUEAAKBAAAAAAKuqkkEAAKBARiuYQKuqkkFYxcU/Xhc8QKuqkkFWcYHAXhc8wKuqkkFWcYHARiuYwKuqkkFYxcU/fn2wpquqkkEAAKBAAAAAAAAAcEEAAKBARiuYQAAAcEFYxcU/Xhc8QAAAcEFWcYHAXhc8wAAAcEFWcYHARiuYwAAAcEFYxcU/fn2wpgAAcEEAAKBAAAAAAKuqOkEAAKBARiuYQKuqOkFYxcU/Xhc8QKuqOkFWcYHAXhc8wKuqOkFWcYHARiuYwKuqOkFYxcU/fn2wpquqOkEAAKBAAAAAAFVVBUEAAKBARiuYQFVVBUFYxcU/Xhc8QFVVBUFWcYHAXhc8wFVVBUFWcYHARiuYwFVVBUFYxcU/fn2wplVVBUEAAKBAAAAAAAAAoEAAAKBARiuYQAAAoEBYxcU/Xhc8QAAAoEBWcYHAXhc8wAAAoEBWcYHARiuYwAAAoEBYxcU/fn2wpgAAoEAAAKBAAAAAAFVV1T8AAKBARiuYQFVV1T9YxcU/Xhc8QFVV1T9WcYHAXhc8wFVV1T9WcYHARiuYwFVV1T9YxcU/fn2wplVV1T8AAKBAAAAAAFVV1b8AAKBARiuYQFVV1b9YxcU/Xhc8QFVV1b9WcYHAXhc8wFVV1b9WcYHARiuYwFVV1b9YxcU/fn2wplVV1b8AAKBAAAAAAAAAoMAAAKBARiuYQAAAoMBYxcU/Xhc8QAAAoMBWcYHAXhc8wAAAoMBWcYHARiuYwAAAoMBYxcU/fn2wpgAAoMAAAKBAAAAAAFVVBcEAAKBARiuYQFVVBcFYxcU/Xhc8QFVVBcFWcYHAXhc8wFVVBcFWcYHARiuYwFVVBcFYxcU/fn2wplVVBcEAAKBAAAAAAKuqOsEAAKBARiuYQKuqOsFYxcU/Xhc8QKuqOsFWcYHAXhc8wKuqOsFWcYHARiuYwKuqOsFYxcU/fn2wpquqOsEAAKBAAAAAAAAAcMEAAKBARiuYQAAAcMFYxcU/Xhc8QAAAcMFWcYHAXhc8wAAAcMFWcYHARiuYwAAAcMFYxcU/fn2wpgAAcMEAAKBAAAAAAKuqksEAAKBARiuYQKuqksFYxcU/Xhc8QKuqksFWcYHAXhc8wKuqksFWcYHARiuYwKuqksFYxcU/fn2wpquqksEAAKBAAAAAAFVVrcEAAKBARiuYQFVVrcFYxcU/Xhc8QFVVrcFWcYHAXhc8wFVVrcFWcYHARiuYwFVVrcFYxcU/fn2wplVVrcEAAKBAAAAAAAAAyMEAAKBARiuYQAAAyMFYxcU/Xhc8QAAAyMFWcYHAXhc8wAAAyMFWcYHARiuYwAAAyMFYxcU/fn2wpgAAyMEAAKBA",
+        "encoding": "base64",
+        "path": [
+         "array",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BufferAttributeModel",
+      "state": {
+       "array": {
+        "dtype": "float32",
+        "shape": [
+         96,
+         3
+        ]
+       },
+       "normalized": false,
+       "version": 0
+      }
+     },
+     "6b013261708842399e49740c435b7669": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "MeshPhysicalMaterialModel",
       "state": {
        "_view_module": null,
        "_view_module_version": "",
-       "intensity": 0.6,
-       "matrixWorldNeedsUpdate": true,
-       "position": [
-        3,
-        5,
-        1
-       ],
-       "shadow": "IPY_MODEL_589f9d46-960f-42c9-8991-c5c341dea1a0",
-       "target": "IPY_MODEL_68a30b6a-5a07-4fa5-84b2-57e47481f497",
-       "type": "DirectionalLight"
+       "color": "green",
+       "type": "MeshPhysicalMaterial"
       }
      },
-     "ffe103fe39344bb4bc4b4c7cf5ed0d90": {
+     "6ccab138-d1e4-48a3-b8b2-2f34ac9bdfec": {
+      "buffers": [
+       {
+        "data": "AAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAgAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAAAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAAAAAgAAAgD8AAACAwsVHvr4Uez8AAAAAFe9Dvr4Uez8M5Rs905A4vr4Uez815pg90Romvr4Uez+t+d09r0INvr4Uez+vQg0+rfndvb4Uez/RGiY+NeaYvb4Uez/TkDg+DOUbvb4Uez8V70M+n1xco74Uez/CxUc+DOUbPb4Uez8V70M+NeaYPb4Uez/TkDg+rfndPb4Uez/RGiY+r0INPr4Uez+vQg0+0RomPr4Uez+t+d0905A4Pr4Uez815pg9Fe9DPr4Uez8M5Rs9wsVHPr4Uez+fXNwjFe9DPr4Uez8M5Ru905A4Pr4Uez815pi90RomPr4Uez+t+d29r0INPr4Uez+vQg2+rfndPb4Uez/RGia+NeaYPb4Uez/TkDi+DOUbPb4Uez8V70O+d0UlJL4Uez/CxUe+DOUbvb4Uez8V70O+NeaYvb4Uez/TkDi+rfndvb4Uez/RGia+r0INvr4Uez+vQg2+0Romvr4Uez+t+d2905A4vr4Uez815pi9Fe9Dvr4Uez8M5Ru9wsVHvr4Uez+fXFykFe/Dvl6DbD8AAAAASivAvl6DbD815pg98wS1vl6DbD8a9hU+wemivl6DbD/JtVk+1IuKvl6DbD/Ui4o+ybVZvl6DbD/B6aI+GvYVvl6DbD/zBLU+NeaYvV6DbD9KK8A+qyDYo16DbD8V78M+NeaYPV6DbD9KK8A+GvYVPl6DbD/zBLU+ybVZPl6DbD/B6aI+1IuKPl6DbD/Ui4o+wemiPl6DbD/JtVk+8wS1Pl6DbD8a9hU+SivAPl6DbD815pg9Fe/DPl6DbD+rIFgkSivAPl6DbD815pi98wS1Pl6DbD8a9hW+wemiPl6DbD/JtVm+1IuKPl6DbD/Ui4q+ybVZPl6DbD/B6aK+GvYVPl6DbD/zBLW+NeaYPV6DbD9KK8C+gBiiJF6DbD8V78O+NeaYvV6DbD9KK8C+GvYVvl6DbD/zBLW+ybVZvl6DbD/B6aK+1IuKvl6DbD/Ui4q+wemivl6DbD/JtVm+8wS1vl6DbD8a9hW+SivAvl6DbD815pi9Fe/Dvl6DbD+rINik2jkOvzHbVD8AAAAAP34LvzHbVD+t+d09UWYDvzHbVD/JtVk+XoPsvjHbVD91CJ4+TiPJvjHbVD9OI8k+dQievjHbVD9eg+w+ybVZvjHbVD9RZgM/rfndvTHbVD8/fgs/Y+IcpDHbVD/aOQ4/rfndPTHbVD8/fgs/ybVZPjHbVD9RZgM/dQiePjHbVD9eg+w+TiPJPjHbVD9OI8k+XoPsPjHbVD91CJ4+UWYDPzHbVD/JtVk+P34LPzHbVD+t+d092jkOPzHbVD9j4pwkP34LPzHbVD+t+d29UWYDPzHbVD/JtVm+XoPsPjHbVD91CJ6+TiPJPjHbVD9OI8m+dQiePjHbVD9eg+y+ybVZPjHbVD9RZgO/rfndPTHbVD8/fgu/lVPrJDHbVD/aOQ6/rfndvTHbVD8/fgu/ybVZvjHbVD9RZgO/dQievjHbVD9eg+y+TiPJvjHbVD9OI8m+XoPsvjHbVD91CJ6+UWYDvzHbVD/JtVm+P34LvzHbVD+t+d292jkOvzHbVD9j4hyl8wQ1v/MENT8AAAAAhooxv/MENT+vQg0+dT0nv/MENT/Ui4o+F4MWv/MENT9OI8k+AAAAv/MENT8AAAA/TiPJvvMENT8XgxY/1IuKvvMENT91PSc/r0INvvMENT+GijE/Bq1HpPMENT/zBDU/r0INPvMENT+GijE/1IuKPvMENT91PSc/TiPJPvMENT8XgxY/AAAAP/MENT8AAAA/F4MWP/MENT9OI8k+dT0nP/MENT/Ui4o+hooxP/MENT+vQg0+8wQ1P/MENT8GrcckhooxP/MENT+vQg2+dT0nP/MENT/Ui4q+F4MWP/MENT9OI8m+AAAAP/MENT8AAAC/TiPJPvMENT8Xgxa/1IuKPvMENT91PSe/r0INPvMENT+GijG/xMEVJfMENT/zBDW/r0INvvMENT+GijG/1IuKvvMENT91PSe/TiPJvvMENT8Xgxa/AAAAv/MENT8AAAC/F4MWv/MENT9OI8m+dT0nv/MENT/Ui4q+hooxv/MENT+vQg2+8wQ1v/MENT8GrUelMdtUv9o5Dj8AAAAAKcRQv9o5Dj/RGiY+TKdEv9o5Dj/B6aI+xfswv9o5Dj9eg+w+F4MWv9o5Dj8XgxY/XoPsvto5Dj/F+zA/wemivto5Dj9Mp0Q/0Romvto5Dj8pxFA/Q8tqpNo5Dj8x21Q/0RomPto5Dj8pxFA/wemiPto5Dj9Mp0Q/XoPsPto5Dj/F+zA/F4MWP9o5Dj8XgxY/xfswP9o5Dj9eg+w+TKdEP9o5Dj/B6aI+KcRQP9o5Dj/RGiY+MdtUP9o5Dj9Dy+okKcRQP9o5Dj/RGia+TKdEP9o5Dj/B6aK+xfswP9o5Dj9eg+y+F4MWP9o5Dj8Xgxa/XoPsPto5Dj/F+zC/wemiPto5Dj9Mp0S/0RomPto5Dj8pxFC/chgwJdo5Dj8x21S/0Romvto5Dj8pxFC/wemivto5Dj9Mp0S/XoPsvto5Dj/F+zC/F4MWv9o5Dj8Xgxa/xfswv9o5Dj9eg+y+TKdEv9o5Dj/B6aK+KcRQv9o5Dj/RGia+MdtUv9o5Dj9Dy2qlXoNsvxXvwz4AAAAA+PdnvxXvwz7TkDg+eoJavxXvwz7zBLU+TKdEvxXvwz5RZgM/dT0nvxXvwz51PSc/UWYDvxXvwz5Mp0Q/8wS1vhXvwz56glo/05A4vhXvwz7492c/znGCpBXvwz5eg2w/05A4PhXvwz7492c/8wS1PhXvwz56glo/UWYDPxXvwz5Mp0Q/dT0nPxXvwz51PSc/TKdEPxXvwz5RZgM/eoJaPxXvwz7zBLU++PdnPxXvwz7TkDg+XoNsPxXvwz7OcQIl+PdnPxXvwz7TkDi+eoJaPxXvwz7zBLW+TKdEPxXvwz5RZgO/dT0nPxXvwz51PSe/UWYDPxXvwz5Mp0S/8wS1PhXvwz56glq/05A4PhXvwz7492e/tapDJRXvwz5eg2y/05A4vhXvwz7492e/8wS1vhXvwz56glq/UWYDvxXvwz5Mp0S/dT0nvxXvwz51PSe/TKdEvxXvwz5RZgO/eoJavxXvwz7zBLW++PdnvxXvwz7TkDi+XoNsvxXvwz7OcYKlvhR7v8LFRz4AAAAAr0F2v8LFRz4V70M++Pdnv8LFRz5KK8A+KcRQv8LFRz4/fgs/hooxv8LFRz6GijE/P34Lv8LFRz4pxFA/SivAvsLFRz7492c/Fe9DvsLFRz6vQXY/rXqKpMLFRz6+FHs/Fe9DPsLFRz6vQXY/SivAPsLFRz7492c/P34LP8LFRz4pxFA/hooxP8LFRz6GijE/KcRQP8LFRz4/fgs/+PdnP8LFRz5KK8A+r0F2P8LFRz4V70M+vhR7P8LFRz6tegolr0F2P8LFRz4V70O++PdnP8LFRz5KK8C+KcRQP8LFRz4/fgu/hooxP8LFRz6GijG/P34LP8LFRz4pxFC/SivAPsLFRz7492e/Fe9DPsLFRz6vQXa/A7hPJcLFRz6+FHu/Fe9DvsLFRz6vQXa/SivAvsLFRz7492e/P34Lv8LFRz4pxFC/hooxv8LFRz6GijG/KcRQv8LFRz4/fgu/+Pdnv8LFRz5KK8C+r0F2v8LFRz4V70O+vhR7v8LFRz6teoqlAACAvzIxjSQAAAAAvhR7vzIxjSTCxUc+XoNsvzIxjSQV78M+MdtUvzIxjSTaOQ4/8wQ1vzIxjSTzBDU/2jkOvzIxjSQx21Q/Fe/DvjIxjSReg2w/wsVHvjIxjSS+FHs/MjGNpDIxjSQAAIA/wsVHPjIxjSS+FHs/Fe/DPjIxjSReg2w/2jkOPzIxjSQx21Q/8wQ1PzIxjSTzBDU/MdtUPzIxjSTaOQ4/XoNsPzIxjSQV78M+vhR7PzIxjSTCxUc+AACAPzIxjSQyMQ0lvhR7PzIxjSTCxUe+XoNsPzIxjSQV78O+MdtUPzIxjSTaOQ6/8wQ1PzIxjSTzBDW/2jkOPzIxjSQx21S/Fe/DPjIxjSReg2y/wsVHPjIxjSS+FHu/yslTJTIxjSQAAIC/wsVHvjIxjSS+FHu/Fe/DvjIxjSReg2y/2jkOvzIxjSQx21S/8wQ1vzIxjSTzBDW/MdtUvzIxjSTaOQ6/XoNsvzIxjSQV78O+vhR7vzIxjSTCxUe+AACAvzIxjSQyMY2lvhR7v8LFR74AAAAAr0F2v8LFR74V70M++Pdnv8LFR75KK8A+KcRQv8LFR74/fgs/hooxv8LFR76GijE/P34Lv8LFR74pxFA/SivAvsLFR77492c/Fe9DvsLFR76vQXY/rXqKpMLFR76+FHs/Fe9DPsLFR76vQXY/SivAPsLFR77492c/P34LP8LFR74pxFA/hooxP8LFR76GijE/KcRQP8LFR74/fgs/+PdnP8LFR75KK8A+r0F2P8LFR74V70M+vhR7P8LFR76tegolr0F2P8LFR74V70O++PdnP8LFR75KK8C+KcRQP8LFR74/fgu/hooxP8LFR76GijG/P34LP8LFR74pxFC/SivAPsLFR77492e/Fe9DPsLFR76vQXa/A7hPJcLFR76+FHu/Fe9DvsLFR76vQXa/SivAvsLFR77492e/P34Lv8LFR74pxFC/hooxv8LFR76GijG/KcRQv8LFR74/fgu/+Pdnv8LFR75KK8C+r0F2v8LFR74V70O+vhR7v8LFR76teoqlXoNsvxXvw74AAAAA+PdnvxXvw77TkDg+eoJavxXvw77zBLU+TKdEvxXvw75RZgM/dT0nvxXvw751PSc/UWYDvxXvw75Mp0Q/8wS1vhXvw756glo/05A4vhXvw77492c/znGCpBXvw75eg2w/05A4PhXvw77492c/8wS1PhXvw756glo/UWYDPxXvw75Mp0Q/dT0nPxXvw751PSc/TKdEPxXvw75RZgM/eoJaPxXvw77zBLU++PdnPxXvw77TkDg+XoNsPxXvw77OcQIl+PdnPxXvw77TkDi+eoJaPxXvw77zBLW+TKdEPxXvw75RZgO/dT0nPxXvw751PSe/UWYDPxXvw75Mp0S/8wS1PhXvw756glq/05A4PhXvw77492e/tapDJRXvw75eg2y/05A4vhXvw77492e/8wS1vhXvw756glq/UWYDvxXvw75Mp0S/dT0nvxXvw751PSe/TKdEvxXvw75RZgO/eoJavxXvw77zBLW++PdnvxXvw77TkDi+XoNsvxXvw77OcYKlMdtUv9o5Dr8AAAAAKcRQv9o5Dr/RGiY+TKdEv9o5Dr/B6aI+xfswv9o5Dr9eg+w+F4MWv9o5Dr8XgxY/XoPsvto5Dr/F+zA/wemivto5Dr9Mp0Q/0Romvto5Dr8pxFA/Q8tqpNo5Dr8x21Q/0RomPto5Dr8pxFA/wemiPto5Dr9Mp0Q/XoPsPto5Dr/F+zA/F4MWP9o5Dr8XgxY/xfswP9o5Dr9eg+w+TKdEP9o5Dr/B6aI+KcRQP9o5Dr/RGiY+MdtUP9o5Dr9Dy+okKcRQP9o5Dr/RGia+TKdEP9o5Dr/B6aK+xfswP9o5Dr9eg+y+F4MWP9o5Dr8Xgxa/XoPsPto5Dr/F+zC/wemiPto5Dr9Mp0S/0RomPto5Dr8pxFC/chgwJdo5Dr8x21S/0Romvto5Dr8pxFC/wemivto5Dr9Mp0S/XoPsvto5Dr/F+zC/F4MWv9o5Dr8Xgxa/xfswv9o5Dr9eg+y+TKdEv9o5Dr/B6aK+KcRQv9o5Dr/RGia+MdtUv9o5Dr9Dy2ql8wQ1v/MENb8AAAAAhooxv/MENb+vQg0+dT0nv/MENb/Ui4o+F4MWv/MENb9OI8k+AAAAv/MENb8AAAA/TiPJvvMENb8XgxY/1IuKvvMENb91PSc/r0INvvMENb+GijE/Bq1HpPMENb/zBDU/r0INPvMENb+GijE/1IuKPvMENb91PSc/TiPJPvMENb8XgxY/AAAAP/MENb8AAAA/F4MWP/MENb9OI8k+dT0nP/MENb/Ui4o+hooxP/MENb+vQg0+8wQ1P/MENb8GrcckhooxP/MENb+vQg2+dT0nP/MENb/Ui4q+F4MWP/MENb9OI8m+AAAAP/MENb8AAAC/TiPJPvMENb8Xgxa/1IuKPvMENb91PSe/r0INPvMENb+GijG/xMEVJfMENb/zBDW/r0INvvMENb+GijG/1IuKvvMENb91PSe/TiPJvvMENb8Xgxa/AAAAv/MENb8AAAC/F4MWv/MENb9OI8m+dT0nv/MENb/Ui4q+hooxv/MENb+vQg2+8wQ1v/MENb8GrUel2jkOvzHbVL8AAAAAP34LvzHbVL+t+d09UWYDvzHbVL/JtVk+XoPsvjHbVL91CJ4+TiPJvjHbVL9OI8k+dQievjHbVL9eg+w+ybVZvjHbVL9RZgM/rfndvTHbVL8/fgs/Y+IcpDHbVL/aOQ4/rfndPTHbVL8/fgs/ybVZPjHbVL9RZgM/dQiePjHbVL9eg+w+TiPJPjHbVL9OI8k+XoPsPjHbVL91CJ4+UWYDPzHbVL/JtVk+P34LPzHbVL+t+d092jkOPzHbVL9j4pwkP34LPzHbVL+t+d29UWYDPzHbVL/JtVm+XoPsPjHbVL91CJ6+TiPJPjHbVL9OI8m+dQiePjHbVL9eg+y+ybVZPjHbVL9RZgO/rfndPTHbVL8/fgu/lVPrJDHbVL/aOQ6/rfndvTHbVL8/fgu/ybVZvjHbVL9RZgO/dQievjHbVL9eg+y+TiPJvjHbVL9OI8m+XoPsvjHbVL91CJ6+UWYDvzHbVL/JtVm+P34LvzHbVL+t+d292jkOvzHbVL9j4hylFe/Dvl6DbL8AAAAASivAvl6DbL815pg98wS1vl6DbL8a9hU+wemivl6DbL/JtVk+1IuKvl6DbL/Ui4o+ybVZvl6DbL/B6aI+GvYVvl6DbL/zBLU+NeaYvV6DbL9KK8A+qyDYo16DbL8V78M+NeaYPV6DbL9KK8A+GvYVPl6DbL/zBLU+ybVZPl6DbL/B6aI+1IuKPl6DbL/Ui4o+wemiPl6DbL/JtVk+8wS1Pl6DbL8a9hU+SivAPl6DbL815pg9Fe/DPl6DbL+rIFgkSivAPl6DbL815pi98wS1Pl6DbL8a9hW+wemiPl6DbL/JtVm+1IuKPl6DbL/Ui4q+ybVZPl6DbL/B6aK+GvYVPl6DbL/zBLW+NeaYPV6DbL9KK8C+gBiiJF6DbL8V78O+NeaYvV6DbL9KK8C+GvYVvl6DbL/zBLW+ybVZvl6DbL/B6aK+1IuKvl6DbL/Ui4q+wemivl6DbL/JtVm+8wS1vl6DbL8a9hW+SivAvl6DbL815pi9Fe/Dvl6DbL+rINikwsVHvr4Ue78AAAAAFe9Dvr4Ue78M5Rs905A4vr4Ue7815pg90Romvr4Ue7+t+d09r0INvr4Ue7+vQg0+rfndvb4Ue7/RGiY+NeaYvb4Ue7/TkDg+DOUbvb4Ue78V70M+n1xco74Ue7/CxUc+DOUbPb4Ue78V70M+NeaYPb4Ue7/TkDg+rfndPb4Ue7/RGiY+r0INPr4Ue7+vQg0+0RomPr4Ue7+t+d0905A4Pr4Ue7815pg9Fe9DPr4Ue78M5Rs9wsVHPr4Ue7+fXNwjFe9DPr4Ue78M5Ru905A4Pr4Ue7815pi90RomPr4Ue7+t+d29r0INPr4Ue7+vQg2+rfndPb4Ue7/RGia+NeaYPb4Ue7/TkDi+DOUbPb4Ue78V70O+d0UlJL4Ue7/CxUe+DOUbvb4Ue78V70O+NeaYvb4Ue7/TkDi+rfndvb4Ue7/RGia+r0INvr4Ue7+vQg2+0Romvr4Ue7+t+d2905A4vr4Ue7815pi9Fe9Dvr4Ue78M5Ru9wsVHvr4Ue7+fXFykMjENpQAAgL8AAAAArXoKpQAAgL+fXNwjznECpQAAgL+rIFgkQ8vqpAAAgL9j4pwkBq3HpAAAgL8GrcckY+KcpAAAgL9Dy+okqyBYpAAAgL/OcQIln1zcowAAgL+tegoldL4bigAAgL8yMQ0ln1zcIwAAgL+tegolqyBYJAAAgL/OcQIlY+KcJAAAgL9Dy+okBq3HJAAAgL8GrcckQ8vqJAAAgL9j4pwkznECJQAAgL+rIFgkrXoKJQAAgL+fXNwjMjENJQAAgL90vpsKrXoKJQAAgL+fXNyjznECJQAAgL+rIFikQ8vqJAAAgL9j4pykBq3HJAAAgL8GrcekY+KcJAAAgL9Dy+qkqyBYJAAAgL/OcQKln1zcIwAAgL+tegqlrp3pCgAAgL8yMQ2ln1zcowAAgL+tegqlqyBYpAAAgL/OcQKlY+KcpAAAgL9Dy+qkBq3HpAAAgL8GrcekQ8vqpAAAgL9j4pykznECpQAAgL+rIFikrXoKpQAAgL+fXNyjMjENpQAAgL90vhuL",
+        "encoding": "base64",
+        "path": [
+         "array",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BufferAttributeModel",
+      "state": {
+       "array": {
+        "dtype": "float32",
+        "shape": [
+         561,
+         3
+        ]
+       },
+       "normalized": false,
+       "version": 0
+      }
+     },
+     "6cecf77295eb4250b92d25f97a0109a4": {
+      "buffers": [
+       {
+        "data": "AAAAAAAAAD8AAMA/AAAAQA==",
+        "encoding": "base64",
+        "path": [
+         "times",
+         "buffer"
+        ]
+       },
+       {
+        "data": "AAAAAJqZmb6amZk+AAAAAA==",
+        "encoding": "base64",
+        "path": [
+         "values",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "NumberKeyframeTrackModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "name": ".bones[2].rotation[x]",
+       "times": {
+        "dtype": "float32",
+        "shape": [
+         4
+        ]
+       },
+       "type": "Bone",
+       "values": {
+        "dtype": "float32",
+        "shape": [
+         4
+        ]
+       }
+      }
+     },
+     "73193216f64c43148db4c217aaec156c": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationClipModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "duration": 2,
+       "tracks": [
+        "IPY_MODEL_083bf74e0bb14cc780c132c6f45fe369",
+        "IPY_MODEL_3df6dd9231c949b287d49324dfa81a70",
+        "IPY_MODEL_6cecf77295eb4250b92d25f97a0109a4",
+        "IPY_MODEL_501309c9ea6645d9bf31b668d3fb03b5"
+       ]
+      }
+     },
+     "7552aee94ae743b785e0610076368d04": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "77127b9ec1b24047921bad2d73055c39": {
       "buffers": [
        {
         "data": "AAAAAAAAAD8AAMA/AAAAQA==",
@@ -2760,26 +1923,955 @@
        }
       ],
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "NumberKeyframeTrackModel",
       "state": {
        "_view_module": null,
        "_view_module_version": "",
        "name": ".bones[1].rotation[y]",
        "times": {
-        "buffer": {},
         "dtype": "float32",
         "shape": [
          4
         ]
        },
+       "type": "Bone",
        "values": {
-        "buffer": {},
         "dtype": "float32",
         "shape": [
          4
         ]
        }
+      }
+     },
+     "788a0da8-6af2-4c03-b17d-160e703f28ae": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "DirectionalLightShadowModel",
+      "state": {
+       "camera": "IPY_MODEL_eeef9249-8d0a-4722-94d9-6bb1a67ba917"
+      }
+     },
+     "78fcabb17e544cedb98e2da04d39833a": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "RendererModel",
+      "state": {
+       "_height": 400,
+       "_width": 600,
+       "camera": "IPY_MODEL_57273feb5932436482db5fdb2fef14c1",
+       "controls": [
+        "IPY_MODEL_06b9defcec5d43c590ef3a90b183a850"
+       ],
+       "layout": "IPY_MODEL_0b470d1a7047445585ed1d80e6314aed",
+       "scene": "IPY_MODEL_a30a5db5479d407da537ee0e6fbde08c",
+       "shadowMap": "IPY_MODEL_46b3539903de4d48b0845ff31db9c37d"
+      }
+     },
+     "7a3e8ed3b0f04db5a936814848893eb1": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BufferGeometryModel",
+      "state": {
+       "_ref_geometry": "IPY_MODEL_5d1449648af748ad8347e0ef7d69cfe1",
+       "_view_module": null,
+       "_view_module_version": "",
+       "attributes": {
+        "normal": "IPY_MODEL_6ccab138-d1e4-48a3-b8b2-2f34ac9bdfec",
+        "position": "IPY_MODEL_1f35e04b-3777-401d-99d1-c9701ca6421a",
+        "uv": "IPY_MODEL_e168ae3c-489d-4bc1-b856-c5813db3068b"
+       },
+       "morphAttributes": {
+        "position": [
+         "IPY_MODEL_58561ef05a0e49f18f5fa24c820d522f"
+        ]
+       }
+      }
+     },
+     "7aeca132905345d6a6cc015626412b03": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "SkinnedMeshModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "children": [
+        "IPY_MODEL_0304ecb4ed1143bcad346b55dcbec86e"
+       ],
+       "geometry": "IPY_MODEL_94c328234ce2462280867b21464b027c",
+       "material": "IPY_MODEL_08ead024f1f44519b180cd3d38f8b379",
+       "modelViewMatrix": [
+        0.7071067811865478,
+        -0.2761723853694969,
+        0.6509445549041193,
+        0,
+        5.551115123125784e-17,
+        0.9205746178983236,
+        0.3905667329424716,
+        0,
+        -0.7071067811865474,
+        -0.276172385369497,
+        0.6509445549041196,
+        0,
+        -1.5987211554602257e-14,
+        -5.329070518200753e-15,
+        -61.44916598294888,
+        1
+       ],
+       "morphTargetInfluences": [],
+       "normalMatrix": [
+        0.7071067811865476,
+        -0.27617238536949684,
+        0.6509445549041191,
+        0,
+        0.9205746178983232,
+        0.3905667329424714,
+        -0.7071067811865474,
+        -0.27617238536949695,
+        0.6509445549041194
+       ],
+       "skeleton": "IPY_MODEL_0e9ff5cfeed54a5ab771a553516b4388",
+       "type": "SkinnedMesh"
+      }
+     },
+     "7f383b17ed7e45cca88270e04d74aac7": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "SceneModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "children": [
+        "IPY_MODEL_34969d8bc62a4767937e79e1822b1430",
+        "IPY_MODEL_63363ddea1874caa82f7532623238abe",
+        "IPY_MODEL_5184d6151d6e428094d4befd90e683d0",
+        "IPY_MODEL_44ed5613512348c6b814e9a155b81b90"
+       ],
+       "type": "Scene"
+      }
+     },
+     "81a1c3daabc5401c8e37654eca74a26e": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationClipModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "duration": 2,
+       "tracks": [
+        "IPY_MODEL_77127b9ec1b24047921bad2d73055c39",
+        "IPY_MODEL_ef36416f060141ffae97bbb628c7536c"
+       ]
+      }
+     },
+     "81e71e98-d507-446f-aa22-7f5d8884182e": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "DirectionalLightShadowModel",
+      "state": {
+       "camera": "IPY_MODEL_1d248d02-d060-4124-b1fa-e3b49454c38f"
+      }
+     },
+     "90c97ebd22934ed7bdb70f7d03db1999": {
+      "buffers": [
+       {
+        "data": "AAAAQAAAQEAAAAAAAAAAAAAAAEAAAEBAAAAAAAAAAAAAAABAAABAQAAAAAAAAAAAAAAAQAAAQEAAAAAAAAAAAAAAAEAAAEBAAAAAAAAAAAAAAABAAABAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAACAPwAAAEAAAAAAAAAAAAAAgD8AAABAAAAAAAAAAAAAAIA/AAAAQAAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAgAAAgD8AAAAAAAAAAAAAAIAAAIA/AAAAAAAAAAAAAACAAACAPwAAAAAAAAAAAAAAgAAAgD8AAAAAAAAAAAAAAIAAAIA/AAAAAAAAAAAAAACAAACAPwAAAAAAAAAA",
+        "encoding": "base64",
+        "path": [
+         "array",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BufferAttributeModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "array": {
+        "dtype": "float32",
+        "shape": [
+         96,
+         4
+        ]
+       },
+       "version": 2
+      }
+     },
+     "90f13a7236c848509621bb279d2c0076": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "94c328234ce2462280867b21464b027c": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BufferGeometryModel",
+      "state": {
+       "_ref_geometry": "IPY_MODEL_307263b8439a49f4842c6aa31b6bbbca",
+       "_view_module": null,
+       "_view_module_version": "",
+       "attributes": {
+        "normal": "IPY_MODEL_dfeed37e-0b4f-4d8b-b05a-74b622ea28ba",
+        "position": "IPY_MODEL_672aa4c0-36d8-4758-a007-63ac41274743",
+        "skinIndex": "IPY_MODEL_90c97ebd22934ed7bdb70f7d03db1999",
+        "skinWeight": "IPY_MODEL_b94fdfe414084756a06e6e6ffe865864",
+        "uv": "IPY_MODEL_423154fa-ae56-4877-9f91-54a3c67f0aa1"
+       }
+      }
+     },
+     "9511ad2b32104926993e6af18c04a38b": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AmbientLightModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "intensity": 0.5,
+       "type": "AmbientLight"
+      }
+     },
+     "9978ff90c29948e5ae61cd5f0073b541": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "OrbitControlsModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "controlling": "IPY_MODEL_63363ddea1874caa82f7532623238abe",
+       "maxAzimuthAngle": "inf",
+       "maxDistance": "inf",
+       "maxZoom": "inf",
+       "minAzimuthAngle": "-inf"
+      }
+     },
+     "9a3660791d55462687b48eb07bf20ff6": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "MeshLambertMaterialModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "color": "green",
+       "type": "MeshLambertMaterial"
+      }
+     },
+     "a13ca1da73be41b798baf45809cb459a": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationClipModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "duration": 3,
+       "tracks": [
+        "IPY_MODEL_ce8669a9caa54dd3834ec085cbc00bd5"
+       ]
+      }
+     },
+     "a30a5db5479d407da537ee0e6fbde08c": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "SceneModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "children": [
+        "IPY_MODEL_7aeca132905345d6a6cc015626412b03",
+        "IPY_MODEL_e4a5438c08b940f4b42bd300ebf063da",
+        "IPY_MODEL_57273feb5932436482db5fdb2fef14c1",
+        "IPY_MODEL_2f876a8eec0a432ea2fc39dad67c5314",
+        "IPY_MODEL_e3968fe7b1f641cd9fddf0e03e2e5d3d"
+       ],
+       "type": "Scene"
+      }
+     },
+     "a9c0a00b62c649eca0eec42e88b29b61": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "MeshPhongMaterialModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "color": "#ff3333",
+       "morphTargets": true,
+       "shininess": 150,
+       "type": "MeshPhongMaterial"
+      }
+     },
+     "aeab0701d0de4f009645ea6ed55269c9": {
+      "buffers": [
+       {
+        "data": "AAAAAAIAAAA=",
+        "encoding": "base64",
+        "path": [
+         "times",
+         "buffer"
+        ]
+       },
+       {
+        "data": "AAAAAMP1yEA=",
+        "encoding": "base64",
+        "path": [
+         "values",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "NumberKeyframeTrackModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "name": ".rotation[y]",
+       "times": {
+        "dtype": "int32",
+        "shape": [
+         2
+        ]
+       },
+       "type": "Bone",
+       "values": {
+        "dtype": "float32",
+        "shape": [
+         2
+        ]
+       }
+      }
+     },
+     "b05ed5ec-faa7-4484-8339-b9c98614d0e5": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "Object3DModel",
+      "state": {
+       "type": "Object3D"
+      }
+     },
+     "b43845c540da4a3bbb438c09111d1dc8": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "ParametricGeometryModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "func": "\nfunction f(origu,origv) {\n    // scale u and v to the ranges I want: [0, 2*pi]\n    var u = 2*Math.PI*origu;\n    var v = 2*Math.PI*origv;\n    \n    var x = Math.sin(u);\n    var y = Math.cos(v);\n    var z = Math.cos(u+v);\n    \n    return new THREE.Vector3(x,y,z)\n}\n",
+       "slices": 16,
+       "stacks": 16,
+       "type": "ParametricGeometry"
+      }
+     },
+     "b60f5c87c1b54db49a65d4a90e42edb4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b84d09220c614f188eb059f6c60ce9eb": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "MeshModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "geometry": "IPY_MODEL_42ac08f0c37d4cb996ae7274a9fe9a02",
+       "material": "IPY_MODEL_6b013261708842399e49740c435b7669",
+       "morphTargetInfluences": [],
+       "position": [
+        2,
+        0,
+        4
+       ]
+      }
+     },
+     "b94fdfe414084756a06e6e6ffe865864": {
+      "buffers": [
+       {
+        "data": "AACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAiogIPt3dXT8AAAAAAAAAAIqICD7d3V0/AAAAAAAAAACKiAg+3d1dPwAAAAAAAAAAiogIPt3dXT8AAAAAAAAAAIqICD7d3V0/AAAAAAAAAACKiAg+3d1dPwAAAAAAAAAAiIiIPry7Oz8AAAAAAAAAAIiIiD68uzs/AAAAAAAAAACIiIg+vLs7PwAAAAAAAAAAiIiIPry7Oz8AAAAAAAAAAIiIiD68uzs/AAAAAAAAAACIiIg+vLs7PwAAAAAAAAAAzczMPpqZGT8AAAAAAAAAAM3MzD6amRk/AAAAAAAAAADNzMw+mpkZPwAAAAAAAAAAzczMPpqZGT8AAAAAAAAAAM3MzD6amRk/AAAAAAAAAADNzMw+mpkZPwAAAAAAAAAAiIgIP+/u7j4AAAAAAAAAAIiICD/v7u4+AAAAAAAAAACIiAg/7+7uPgAAAAAAAAAAiIgIP+/u7j4AAAAAAAAAAIiICD/v7u4+AAAAAAAAAACIiAg/7+7uPgAAAAAAAAAAq6oqP6qqqj4AAAAAAAAAAKuqKj+qqqo+AAAAAAAAAACrqio/qqqqPgAAAAAAAAAAq6oqP6qqqj4AAAAAAAAAAKuqKj+qqqo+AAAAAAAAAACrqio/qqqqPgAAAAAAAAAAzcxMP83MTD4AAAAAAAAAAM3MTD/NzEw+AAAAAAAAAADNzEw/zcxMPgAAAAAAAAAAzcxMP83MTD4AAAAAAAAAAM3MTD/NzEw+AAAAAAAAAADNzEw/zcxMPgAAAAAAAAAA7+5uP4iIiD0AAAAAAAAAAO/ubj+IiIg9AAAAAAAAAADv7m4/iIiIPQAAAAAAAAAA7+5uP4iIiD0AAAAAAAAAAO/ubj+IiIg9AAAAAAAAAADv7m4/iIiIPQAAAAAAAAAAiIiIPe/ubj8AAAAAAAAAAIiIiD3v7m4/AAAAAAAAAACIiIg97+5uPwAAAAAAAAAAiIiIPe/ubj8AAAAAAAAAAIiIiD3v7m4/AAAAAAAAAACIiIg97+5uPwAAAAAAAAAAzcxMPs3MTD8AAAAAAAAAAM3MTD7NzEw/AAAAAAAAAADNzEw+zcxMPwAAAAAAAAAAzcxMPs3MTD8AAAAAAAAAAM3MTD7NzEw/AAAAAAAAAADNzEw+zcxMPwAAAAAAAAAAqqqqPquqKj8AAAAAAAAAAKqqqj6rqio/AAAAAAAAAACqqqo+q6oqPwAAAAAAAAAAqqqqPquqKj8AAAAAAAAAAKqqqj6rqio/AAAAAAAAAACqqqo+q6oqPwAAAAAAAAAA7+7uPoiICD8AAAAAAAAAAO/u7j6IiAg/AAAAAAAAAADv7u4+iIgIPwAAAAAAAAAA7+7uPoiICD8AAAAAAAAAAO/u7j6IiAg/AAAAAAAAAADv7u4+iIgIPwAAAAAAAAAAmpkZP83MzD4AAAAAAAAAAJqZGT/NzMw+AAAAAAAAAACamRk/zczMPgAAAAAAAAAAmpkZP83MzD4AAAAAAAAAAJqZGT/NzMw+AAAAAAAAAACamRk/zczMPgAAAAAAAAAAvLs7P4iIiD4AAAAAAAAAALy7Oz+IiIg+AAAAAAAAAAC8uzs/iIiIPgAAAAAAAAAAvLs7P4iIiD4AAAAAAAAAALy7Oz+IiIg+AAAAAAAAAAC8uzs/iIiIPgAAAAAAAAAA3d1dP4qICD4AAAAAAAAAAN3dXT+KiAg+AAAAAAAAAADd3V0/iogIPgAAAAAAAAAA3d1dP4qICD4AAAAAAAAAAN3dXT+KiAg+AAAAAAAAAADd3V0/iogIPgAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAA",
+        "encoding": "base64",
+        "path": [
+         "array",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BufferAttributeModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "array": {
+        "dtype": "float32",
+        "shape": [
+         96,
+         4
+        ]
+       },
+       "version": 2
+      }
+     },
+     "ba310b776b554a6f9991fea547d71563": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "MeshModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "geometry": "IPY_MODEL_c0ad123a88c7437e90516700362ba6d2",
+       "material": "IPY_MODEL_eac5e55c4fd941afb1e51a8e58746b2d",
+       "morphTargetInfluences": []
+      }
+     },
+     "bb88f78d-528d-4ddd-9c4f-3fd6e2f8912b": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "Object3DModel",
+      "state": {
+       "type": "Object3D"
+      }
+     },
+     "bf34a5bef01f45cd8109e959e9ac5ce3": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationMixerModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "rootObject": "IPY_MODEL_7aeca132905345d6a6cc015626412b03",
+       "time": 1.3092900000000003
+      }
+     },
+     "c0ad123a88c7437e90516700362ba6d2": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "SphereBufferGeometryModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "heightSegments": 16,
+       "type": "SphereBufferGeometry",
+       "widthSegments": 32
+      }
+     },
+     "c0b0f1b6497a4047ad189eca7325af5e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c170ed5c49bd4f5e8a41bc6a0d3b7c6f": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationMixerModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "rootObject": "IPY_MODEL_34969d8bc62a4767937e79e1822b1430"
+      }
+     },
+     "c5a814d39f1c43b5913e5d2a7a83179b": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationActionModel",
+      "state": {
+       "_model_module": "jupyter-threejs",
+       "_model_module_version": "1.0.0-beta.4",
+       "_model_name": "AnimationActionModel",
+       "_view_module_version": "1.0.0-beta.4",
+       "clip": "IPY_MODEL_47ed4691f03f4803920d786fcbacbedb",
+       "layout": "IPY_MODEL_4a77782b47ed4bb99e0af12b532a03cc",
+       "localRoot": "IPY_MODEL_482685a7d8564069ab800ecebd478b4d",
+       "mixer": "IPY_MODEL_12eaad2aa913455282c722b2bfc216c0",
+       "repititions": "inf"
+      }
+     },
+     "ca317ae15cd645c296683f3ddf31715b": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "DirectionalLightModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "intensity": 0.6,
+       "matrixWorldNeedsUpdate": true,
+       "position": [
+        3,
+        5,
+        1
+       ],
+       "shadow": "IPY_MODEL_d21a2b3c-bdde-4569-bbb9-03513aedaa13",
+       "target": "IPY_MODEL_b05ed5ec-faa7-4484-8339-b9c98614d0e5",
+       "type": "DirectionalLight"
+      }
+     },
+     "cc3451bcdcbe408a94882bd181e7a9ab": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationMixerModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "rootObject": "IPY_MODEL_ba310b776b554a6f9991fea547d71563"
+      }
+     },
+     "ce304bc2137b4e31a04027c61c8f32af": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationClipModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "duration": 1.5,
+       "tracks": [
+        "IPY_MODEL_1db5d15e00c942c5ba917773100649c0"
+       ]
+      }
+     },
+     "ce8669a9caa54dd3834ec085cbc00bd5": {
+      "buffers": [
+       {
+        "data": "AAAAAAAAwD8AAEBA",
+        "encoding": "base64",
+        "path": [
+         "times",
+         "buffer"
+        ]
+       },
+       {
+        "data": "AAAAAAAAIEAAAAAA",
+        "encoding": "base64",
+        "path": [
+         "values",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "NumberKeyframeTrackModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "name": ".morphTargetInfluences[0]",
+       "times": {
+        "dtype": "float32",
+        "shape": [
+         3
+        ]
+       },
+       "type": "Bone",
+       "values": {
+        "dtype": "float32",
+        "shape": [
+         3
+        ]
+       }
+      }
+     },
+     "d21a2b3c-bdde-4569-bbb9-03513aedaa13": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "DirectionalLightShadowModel",
+      "state": {
+       "camera": "IPY_MODEL_0d5faea4-8e36-4061-8194-ef284a0fcebe"
+      }
+     },
+     "d3757a6356d0474dacdcab96327584c6": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "DirectionalLightModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "matrixWorldNeedsUpdate": true,
+       "position": [
+        0,
+        10,
+        10
+       ],
+       "shadow": "IPY_MODEL_81e71e98-d507-446f-aa22-7f5d8884182e",
+       "target": "IPY_MODEL_0568aa6c-903a-43ec-9048-d80ce23b1bc9",
+       "type": "DirectionalLight"
+      }
+     },
+     "d56aa285ba104cdc9cb440e60545c365": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d57ddb4b69ff4e8d83be86d273accb8e": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PerspectiveCameraModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "aspect": 1.5,
+       "position": [
+        10,
+        6,
+        10
+       ],
+       "projectionMatrix": [
+        1.4296712803397058,
+        0,
+        0,
+        0,
+        0,
+        2.1445069205095586,
+        0,
+        0,
+        0,
+        0,
+        -1.00010000500025,
+        -1,
+        0,
+        0,
+        -0.200010000500025,
+        0
+       ]
+      }
+     },
+     "d73b3b15e93a4857846f4fd2a5b9f149": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dbb4713aa5f84fa5bd17d8b52668f938": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "MeshLambertMaterialModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "color": "yellow",
+       "side": "BackSide",
+       "type": "MeshLambertMaterial"
+      }
+     },
+     "dc28a62ee6f44e31822b2f4270e607a0": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationActionModel",
+      "state": {
+       "_model_module": "jupyter-threejs",
+       "_model_module_version": "1.0.0-beta.4",
+       "_model_name": "AnimationActionModel",
+       "_view_module_version": "1.0.0-beta.4",
+       "clip": "IPY_MODEL_de355b05df5e4f509c655ebe70f6107a",
+       "layout": "IPY_MODEL_c0b0f1b6497a4047ad189eca7325af5e",
+       "localRoot": "IPY_MODEL_1699b6b842414fd2a3618d34b4d864e5",
+       "mixer": "IPY_MODEL_f7b616204a3848018cd138bc6ec6ea6d",
+       "repititions": "inf"
+      }
+     },
+     "dd0b2b8c072240fdbda967972cb2f55f": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationActionModel",
+      "state": {
+       "_model_module": "jupyter-threejs",
+       "_model_module_version": "1.0.0-beta.4",
+       "_model_name": "AnimationActionModel",
+       "_view_module_version": "1.0.0-beta.4",
+       "clip": "IPY_MODEL_ce304bc2137b4e31a04027c61c8f32af",
+       "layout": "IPY_MODEL_90f13a7236c848509621bb279d2c0076",
+       "localRoot": "IPY_MODEL_ba310b776b554a6f9991fea547d71563",
+       "mixer": "IPY_MODEL_cc3451bcdcbe408a94882bd181e7a9ab",
+       "repititions": "inf"
+      }
+     },
+     "de355b05df5e4f509c655ebe70f6107a": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationClipModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "duration": 2,
+       "tracks": [
+        "IPY_MODEL_aeab0701d0de4f009645ea6ed55269c9"
+       ]
+      }
+     },
+     "de84ba1f-344d-4d39-bcfe-7c0e418f5ac5": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "DirectionalLightShadowModel",
+      "state": {
+       "camera": "IPY_MODEL_5e3aa4f7-79fb-45c6-9ea3-219c55baf85c"
+      }
+     },
+     "dfeed37e-0b4f-4d8b-b05a-74b622ea28ba": {
+      "buffers": [
+       {
+        "data": "AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/AAAAAAAAAAAAAIA/cXhzPwAAAAB6N54+GHkWPwAAAAC9G0+/GHkWvwAAAAC9G0+/cXhzvwAAAAB6N54+MjGNpQAAAAAAAIA/",
+        "encoding": "base64",
+        "path": [
+         "array",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BufferAttributeModel",
+      "state": {
+       "array": {
+        "dtype": "float32",
+        "shape": [
+         96,
+         3
+        ]
+       },
+       "normalized": false,
+       "version": 0
+      }
+     },
+     "e168ae3c-489d-4bc1-b856-c5813db3068b": {
+      "buffers": [
+       {
+        "data": "AAAAAAAAgD8AAAA9AACAPwAAgD0AAIA/AADAPQAAgD8AAAA+AACAPwAAID4AAIA/AABAPgAAgD8AAGA+AACAPwAAgD4AAIA/AACQPgAAgD8AAKA+AACAPwAAsD4AAIA/AADAPgAAgD8AANA+AACAPwAA4D4AAIA/AADwPgAAgD8AAAA/AACAPwAACD8AAIA/AAAQPwAAgD8AABg/AACAPwAAID8AAIA/AAAoPwAAgD8AADA/AACAPwAAOD8AAIA/AABAPwAAgD8AAEg/AACAPwAAUD8AAIA/AABYPwAAgD8AAGA/AACAPwAAaD8AAIA/AABwPwAAgD8AAHg/AACAPwAAgD8AAIA/AAAAAAAAcD8AAAA9AABwPwAAgD0AAHA/AADAPQAAcD8AAAA+AABwPwAAID4AAHA/AABAPgAAcD8AAGA+AABwPwAAgD4AAHA/AACQPgAAcD8AAKA+AABwPwAAsD4AAHA/AADAPgAAcD8AANA+AABwPwAA4D4AAHA/AADwPgAAcD8AAAA/AABwPwAACD8AAHA/AAAQPwAAcD8AABg/AABwPwAAID8AAHA/AAAoPwAAcD8AADA/AABwPwAAOD8AAHA/AABAPwAAcD8AAEg/AABwPwAAUD8AAHA/AABYPwAAcD8AAGA/AABwPwAAaD8AAHA/AABwPwAAcD8AAHg/AABwPwAAgD8AAHA/AAAAAAAAYD8AAAA9AABgPwAAgD0AAGA/AADAPQAAYD8AAAA+AABgPwAAID4AAGA/AABAPgAAYD8AAGA+AABgPwAAgD4AAGA/AACQPgAAYD8AAKA+AABgPwAAsD4AAGA/AADAPgAAYD8AANA+AABgPwAA4D4AAGA/AADwPgAAYD8AAAA/AABgPwAACD8AAGA/AAAQPwAAYD8AABg/AABgPwAAID8AAGA/AAAoPwAAYD8AADA/AABgPwAAOD8AAGA/AABAPwAAYD8AAEg/AABgPwAAUD8AAGA/AABYPwAAYD8AAGA/AABgPwAAaD8AAGA/AABwPwAAYD8AAHg/AABgPwAAgD8AAGA/AAAAAAAAUD8AAAA9AABQPwAAgD0AAFA/AADAPQAAUD8AAAA+AABQPwAAID4AAFA/AABAPgAAUD8AAGA+AABQPwAAgD4AAFA/AACQPgAAUD8AAKA+AABQPwAAsD4AAFA/AADAPgAAUD8AANA+AABQPwAA4D4AAFA/AADwPgAAUD8AAAA/AABQPwAACD8AAFA/AAAQPwAAUD8AABg/AABQPwAAID8AAFA/AAAoPwAAUD8AADA/AABQPwAAOD8AAFA/AABAPwAAUD8AAEg/AABQPwAAUD8AAFA/AABYPwAAUD8AAGA/AABQPwAAaD8AAFA/AABwPwAAUD8AAHg/AABQPwAAgD8AAFA/AAAAAAAAQD8AAAA9AABAPwAAgD0AAEA/AADAPQAAQD8AAAA+AABAPwAAID4AAEA/AABAPgAAQD8AAGA+AABAPwAAgD4AAEA/AACQPgAAQD8AAKA+AABAPwAAsD4AAEA/AADAPgAAQD8AANA+AABAPwAA4D4AAEA/AADwPgAAQD8AAAA/AABAPwAACD8AAEA/AAAQPwAAQD8AABg/AABAPwAAID8AAEA/AAAoPwAAQD8AADA/AABAPwAAOD8AAEA/AABAPwAAQD8AAEg/AABAPwAAUD8AAEA/AABYPwAAQD8AAGA/AABAPwAAaD8AAEA/AABwPwAAQD8AAHg/AABAPwAAgD8AAEA/AAAAAAAAMD8AAAA9AAAwPwAAgD0AADA/AADAPQAAMD8AAAA+AAAwPwAAID4AADA/AABAPgAAMD8AAGA+AAAwPwAAgD4AADA/AACQPgAAMD8AAKA+AAAwPwAAsD4AADA/AADAPgAAMD8AANA+AAAwPwAA4D4AADA/AADwPgAAMD8AAAA/AAAwPwAACD8AADA/AAAQPwAAMD8AABg/AAAwPwAAID8AADA/AAAoPwAAMD8AADA/AAAwPwAAOD8AADA/AABAPwAAMD8AAEg/AAAwPwAAUD8AADA/AABYPwAAMD8AAGA/AAAwPwAAaD8AADA/AABwPwAAMD8AAHg/AAAwPwAAgD8AADA/AAAAAAAAID8AAAA9AAAgPwAAgD0AACA/AADAPQAAID8AAAA+AAAgPwAAID4AACA/AABAPgAAID8AAGA+AAAgPwAAgD4AACA/AACQPgAAID8AAKA+AAAgPwAAsD4AACA/AADAPgAAID8AANA+AAAgPwAA4D4AACA/AADwPgAAID8AAAA/AAAgPwAACD8AACA/AAAQPwAAID8AABg/AAAgPwAAID8AACA/AAAoPwAAID8AADA/AAAgPwAAOD8AACA/AABAPwAAID8AAEg/AAAgPwAAUD8AACA/AABYPwAAID8AAGA/AAAgPwAAaD8AACA/AABwPwAAID8AAHg/AAAgPwAAgD8AACA/AAAAAAAAED8AAAA9AAAQPwAAgD0AABA/AADAPQAAED8AAAA+AAAQPwAAID4AABA/AABAPgAAED8AAGA+AAAQPwAAgD4AABA/AACQPgAAED8AAKA+AAAQPwAAsD4AABA/AADAPgAAED8AANA+AAAQPwAA4D4AABA/AADwPgAAED8AAAA/AAAQPwAACD8AABA/AAAQPwAAED8AABg/AAAQPwAAID8AABA/AAAoPwAAED8AADA/AAAQPwAAOD8AABA/AABAPwAAED8AAEg/AAAQPwAAUD8AABA/AABYPwAAED8AAGA/AAAQPwAAaD8AABA/AABwPwAAED8AAHg/AAAQPwAAgD8AABA/AAAAAAAAAD8AAAA9AAAAPwAAgD0AAAA/AADAPQAAAD8AAAA+AAAAPwAAID4AAAA/AABAPgAAAD8AAGA+AAAAPwAAgD4AAAA/AACQPgAAAD8AAKA+AAAAPwAAsD4AAAA/AADAPgAAAD8AANA+AAAAPwAA4D4AAAA/AADwPgAAAD8AAAA/AAAAPwAACD8AAAA/AAAQPwAAAD8AABg/AAAAPwAAID8AAAA/AAAoPwAAAD8AADA/AAAAPwAAOD8AAAA/AABAPwAAAD8AAEg/AAAAPwAAUD8AAAA/AABYPwAAAD8AAGA/AAAAPwAAaD8AAAA/AABwPwAAAD8AAHg/AAAAPwAAgD8AAAA/AAAAAAAA4D4AAAA9AADgPgAAgD0AAOA+AADAPQAA4D4AAAA+AADgPgAAID4AAOA+AABAPgAA4D4AAGA+AADgPgAAgD4AAOA+AACQPgAA4D4AAKA+AADgPgAAsD4AAOA+AADAPgAA4D4AANA+AADgPgAA4D4AAOA+AADwPgAA4D4AAAA/AADgPgAACD8AAOA+AAAQPwAA4D4AABg/AADgPgAAID8AAOA+AAAoPwAA4D4AADA/AADgPgAAOD8AAOA+AABAPwAA4D4AAEg/AADgPgAAUD8AAOA+AABYPwAA4D4AAGA/AADgPgAAaD8AAOA+AABwPwAA4D4AAHg/AADgPgAAgD8AAOA+AAAAAAAAwD4AAAA9AADAPgAAgD0AAMA+AADAPQAAwD4AAAA+AADAPgAAID4AAMA+AABAPgAAwD4AAGA+AADAPgAAgD4AAMA+AACQPgAAwD4AAKA+AADAPgAAsD4AAMA+AADAPgAAwD4AANA+AADAPgAA4D4AAMA+AADwPgAAwD4AAAA/AADAPgAACD8AAMA+AAAQPwAAwD4AABg/AADAPgAAID8AAMA+AAAoPwAAwD4AADA/AADAPgAAOD8AAMA+AABAPwAAwD4AAEg/AADAPgAAUD8AAMA+AABYPwAAwD4AAGA/AADAPgAAaD8AAMA+AABwPwAAwD4AAHg/AADAPgAAgD8AAMA+AAAAAAAAoD4AAAA9AACgPgAAgD0AAKA+AADAPQAAoD4AAAA+AACgPgAAID4AAKA+AABAPgAAoD4AAGA+AACgPgAAgD4AAKA+AACQPgAAoD4AAKA+AACgPgAAsD4AAKA+AADAPgAAoD4AANA+AACgPgAA4D4AAKA+AADwPgAAoD4AAAA/AACgPgAACD8AAKA+AAAQPwAAoD4AABg/AACgPgAAID8AAKA+AAAoPwAAoD4AADA/AACgPgAAOD8AAKA+AABAPwAAoD4AAEg/AACgPgAAUD8AAKA+AABYPwAAoD4AAGA/AACgPgAAaD8AAKA+AABwPwAAoD4AAHg/AACgPgAAgD8AAKA+AAAAAAAAgD4AAAA9AACAPgAAgD0AAIA+AADAPQAAgD4AAAA+AACAPgAAID4AAIA+AABAPgAAgD4AAGA+AACAPgAAgD4AAIA+AACQPgAAgD4AAKA+AACAPgAAsD4AAIA+AADAPgAAgD4AANA+AACAPgAA4D4AAIA+AADwPgAAgD4AAAA/AACAPgAACD8AAIA+AAAQPwAAgD4AABg/AACAPgAAID8AAIA+AAAoPwAAgD4AADA/AACAPgAAOD8AAIA+AABAPwAAgD4AAEg/AACAPgAAUD8AAIA+AABYPwAAgD4AAGA/AACAPgAAaD8AAIA+AABwPwAAgD4AAHg/AACAPgAAgD8AAIA+AAAAAAAAQD4AAAA9AABAPgAAgD0AAEA+AADAPQAAQD4AAAA+AABAPgAAID4AAEA+AABAPgAAQD4AAGA+AABAPgAAgD4AAEA+AACQPgAAQD4AAKA+AABAPgAAsD4AAEA+AADAPgAAQD4AANA+AABAPgAA4D4AAEA+AADwPgAAQD4AAAA/AABAPgAACD8AAEA+AAAQPwAAQD4AABg/AABAPgAAID8AAEA+AAAoPwAAQD4AADA/AABAPgAAOD8AAEA+AABAPwAAQD4AAEg/AABAPgAAUD8AAEA+AABYPwAAQD4AAGA/AABAPgAAaD8AAEA+AABwPwAAQD4AAHg/AABAPgAAgD8AAEA+AAAAAAAAAD4AAAA9AAAAPgAAgD0AAAA+AADAPQAAAD4AAAA+AAAAPgAAID4AAAA+AABAPgAAAD4AAGA+AAAAPgAAgD4AAAA+AACQPgAAAD4AAKA+AAAAPgAAsD4AAAA+AADAPgAAAD4AANA+AAAAPgAA4D4AAAA+AADwPgAAAD4AAAA/AAAAPgAACD8AAAA+AAAQPwAAAD4AABg/AAAAPgAAID8AAAA+AAAoPwAAAD4AADA/AAAAPgAAOD8AAAA+AABAPwAAAD4AAEg/AAAAPgAAUD8AAAA+AABYPwAAAD4AAGA/AAAAPgAAaD8AAAA+AABwPwAAAD4AAHg/AAAAPgAAgD8AAAA+AAAAAAAAgD0AAAA9AACAPQAAgD0AAIA9AADAPQAAgD0AAAA+AACAPQAAID4AAIA9AABAPgAAgD0AAGA+AACAPQAAgD4AAIA9AACQPgAAgD0AAKA+AACAPQAAsD4AAIA9AADAPgAAgD0AANA+AACAPQAA4D4AAIA9AADwPgAAgD0AAAA/AACAPQAACD8AAIA9AAAQPwAAgD0AABg/AACAPQAAID8AAIA9AAAoPwAAgD0AADA/AACAPQAAOD8AAIA9AABAPwAAgD0AAEg/AACAPQAAUD8AAIA9AABYPwAAgD0AAGA/AACAPQAAaD8AAIA9AABwPwAAgD0AAHg/AACAPQAAgD8AAIA9AAAAAAAAAAAAAAA9AAAAAAAAgD0AAAAAAADAPQAAAAAAAAA+AAAAAAAAID4AAAAAAABAPgAAAAAAAGA+AAAAAAAAgD4AAAAAAACQPgAAAAAAAKA+AAAAAAAAsD4AAAAAAADAPgAAAAAAANA+AAAAAAAA4D4AAAAAAADwPgAAAAAAAAA/AAAAAAAACD8AAAAAAAAQPwAAAAAAABg/AAAAAAAAID8AAAAAAAAoPwAAAAAAADA/AAAAAAAAOD8AAAAAAABAPwAAAAAAAEg/AAAAAAAAUD8AAAAAAABYPwAAAAAAAGA/AAAAAAAAaD8AAAAAAABwPwAAAAAAAHg/AAAAAAAAgD8AAAAA",
+        "encoding": "base64",
+        "path": [
+         "array",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BufferAttributeModel",
+      "state": {
+       "array": {
+        "dtype": "float32",
+        "shape": [
+         561,
+         2
+        ]
+       },
+       "normalized": false,
+       "version": 0
+      }
+     },
+     "e3968fe7b1f641cd9fddf0e03e2e5d3d": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AmbientLightModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "intensity": 0.5,
+       "type": "AmbientLight"
+      }
+     },
+     "e4a5438c08b940f4b42bd300ebf063da": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "SkeletonHelperModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "root": "IPY_MODEL_7aeca132905345d6a6cc015626412b03",
+       "type": "LineSegments"
+      }
+     },
+     "e7bb1ceb498a400e8b59b11725e073be": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "RendererModel",
+      "state": {
+       "_height": 400,
+       "_width": 600,
+       "camera": "IPY_MODEL_482685a7d8564069ab800ecebd478b4d",
+       "controls": [
+        "IPY_MODEL_1ba7f975416e49a79587b3ef57cde0a6"
+       ],
+       "layout": "IPY_MODEL_d56aa285ba104cdc9cb440e60545c365",
+       "scene": "IPY_MODEL_087e4843e5a74971b1520d088a7d56a4",
+       "shadowMap": "IPY_MODEL_f26c9abf163742a2953fbb7e505414d3"
+      }
+     },
+     "eac5e55c4fd941afb1e51a8e58746b2d": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "MeshStandardMaterialModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "color": "red",
+       "type": "MeshStandardMaterial"
+      }
+     },
+     "eeef9249-8d0a-4722-94d9-6bb1a67ba917": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "OrthographicCameraModel",
+      "state": {
+       "bottom": -5,
+       "far": 500,
+       "left": -5,
+       "near": 0.5,
+       "projectionMatrix": [
+        0.2,
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0,
+        0,
+        0,
+        0,
+        -0.004004004004004004,
+        0,
+        0,
+        0,
+        -1.002002002002002,
+        1
+       ],
+       "right": 5,
+       "top": 5
+      }
+     },
+     "ef36416f060141ffae97bbb628c7536c": {
+      "buffers": [
+       {
+        "data": "AAAAAAAAAD8AAMA/AAAAQA==",
+        "encoding": "base64",
+        "path": [
+         "times",
+         "buffer"
+        ]
+       },
+       {
+        "data": "AAAAADMzMz8zMzO/AAAAAA==",
+        "encoding": "base64",
+        "path": [
+         "values",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "NumberKeyframeTrackModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "name": ".bones[2].rotation[y]",
+       "times": {
+        "dtype": "float32",
+        "shape": [
+         4
+        ]
+       },
+       "type": "Bone",
+       "values": {
+        "dtype": "float32",
+        "shape": [
+         4
+        ]
+       }
+      }
+     },
+     "f26c9abf163742a2953fbb7e505414d3": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "f61d2da9bc71495c9a35abb24e81beea": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationActionModel",
+      "state": {
+       "_model_module": "jupyter-threejs",
+       "_model_module_version": "1.0.0-beta.4",
+       "_model_name": "AnimationActionModel",
+       "_view_module_version": "1.0.0-beta.4",
+       "clip": "IPY_MODEL_a13ca1da73be41b798baf45809cb459a",
+       "layout": "IPY_MODEL_4d88177b29b547febd8f39a7a0f94855",
+       "localRoot": "IPY_MODEL_34969d8bc62a4767937e79e1822b1430",
+       "mixer": "IPY_MODEL_c170ed5c49bd4f5e8a41bc6a0d3b7c6f",
+       "repititions": "inf"
+      }
+     },
+     "f7b616204a3848018cd138bc6ec6ea6d": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "AnimationMixerModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "rootObject": "IPY_MODEL_1699b6b842414fd2a3618d34b4d864e5"
+      }
+     },
+     "fd06057c9cdd49b6a53d753db8730feb": {
+      "buffers": [
+       {
+        "data": "AAAAAAIAAAAFAAAA",
+        "encoding": "base64",
+        "path": [
+         "times",
+         "buffer"
+        ]
+       },
+       {
+        "data": "AAAgQQAAwEAAACBBmpnJQIXrcUCamclAUrg+wD0KVz8zMxNB",
+        "encoding": "base64",
+        "path": [
+         "values",
+         "buffer"
+        ]
+       }
+      ],
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "VectorKeyframeTrackModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "name": ".position",
+       "times": {
+        "dtype": "int32",
+        "shape": [
+         3
+        ]
+       },
+       "type": "Bone",
+       "values": {
+        "dtype": "float32",
+        "shape": [
+         9
+        ]
+       }
+      }
+     },
+     "fe7d6be53ed14f83aefad6e22b36689b": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BoneModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "children": [
+        "IPY_MODEL_3364136f8f3946b3a687f479e6d395a9"
+       ],
+       "position": [
+        0,
+        25,
+        0
+       ],
+       "type": "Bone"
       }
      }
     },

--- a/examples/Geometries.ipynb
+++ b/examples/Geometries.ipynb
@@ -26,7 +26,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b70a7dbc0d644cbeb8aed0c9718d1dd4",
+       "model_id": "c0a6d80e32e04b8e9ecb513a97c29c44",
        "version_major": 2,
        "version_minor": 0
       },
@@ -46,7 +46,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "Preview(child=BoxGeometry(depth=15.0, depthSegments=15, heightSegments=10, width=5.0, widthSegments=5), shadowMap=WebGLShadowMap())"
+       "Preview(child=BoxGeometry(depth=15.0, depthSegments=15, height=10.0, heightSegments=10, width=5.0, widthSegments=5), shadowMap=WebGLShadowMap())"
       ]
      },
      "metadata": {},
@@ -71,7 +71,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "23baf9e9e21a417e80b9e72f00e4750c",
+       "model_id": "dd84ce98756e4f30988caebe9c36c439",
        "version_major": 2,
        "version_minor": 0
       },
@@ -91,7 +91,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "Preview(child=BoxBufferGeometry(depth=15.0, depthSegments=15, heightSegments=10, width=5.0, widthSegments=5), shadowMap=WebGLShadowMap())"
+       "Preview(child=BoxBufferGeometry(depth=15.0, depthSegments=15, height=10.0, heightSegments=10, width=5.0, widthSegments=5), shadowMap=WebGLShadowMap())"
       ]
      },
      "metadata": {},
@@ -116,7 +116,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c2238c75c93e49e4a5fd1b3d4f2c677b",
+       "model_id": "aabb3f3575dd43b4877c02b6e5707a3d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -159,7 +159,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a2b539854afe4dbb873326de9a5cfb81",
+       "model_id": "5e77925146584791b54d8a375913c6a7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -202,7 +202,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cc899f646acf4669a29a82fb71886cda",
+       "model_id": "6820dfcf32b347cbb550e6817108480f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -249,7 +249,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1badb1fbb4da4126bb76d06b0f4fc1f2",
+       "model_id": "d28fa3cf072f4ccd8b8c8bd2646dabb8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -296,7 +296,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "99d32d6e450c469ab744501c8842205f",
+       "model_id": "37c530393ec14198bcc09c440d81d0b4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -355,7 +355,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0f003cb994a7483bb22bfa0b048c5100",
+       "model_id": "7e75685b60a24f0688812ba6c0830aee",
        "version_major": 2,
        "version_minor": 0
       },
@@ -394,7 +394,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ed4a030057d4483d8200c45ecf58c840",
+       "model_id": "0e0abf794f07487ba5a509c6e0cae629",
        "version_major": 2,
        "version_minor": 0
       },
@@ -442,7 +442,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "23ffc7b063ea4e6bb7d04c665a7e6fa2",
+       "model_id": "be34347f79d541f5aecc724c1709dbe1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -481,7 +481,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8e6ce3d8be2b4d51839370dc75a76d92",
+       "model_id": "fff3cac17f074f139ffa650ea971089c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -527,7 +527,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "029efdf8a37f4b0a8e6c0b07863524a6",
+       "model_id": "565a42ada56a456b80d4a9411a9c7808",
        "version_major": 2,
        "version_minor": 0
       },
@@ -547,7 +547,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "Preview(child=PlaneGeometry(height=15.0, heightSegments=10, widthSegments=5), shadowMap=WebGLShadowMap())"
+       "Preview(child=PlaneGeometry(height=15.0, heightSegments=10, width=10.0, widthSegments=5), shadowMap=WebGLShadowMap())"
       ]
      },
      "metadata": {},
@@ -570,7 +570,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "91c565117edc44e48cbc48bf37637cc8",
+       "model_id": "e6b4f575041e427cb0206d0d5da15cf3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -590,7 +590,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "Preview(child=PlaneBufferGeometry(height=15.0, heightSegments=10, widthSegments=5), shadowMap=WebGLShadowMap())"
+       "Preview(child=PlaneBufferGeometry(height=15.0, heightSegments=10, width=10.0, widthSegments=5), shadowMap=WebGLShadowMap())"
       ]
      },
      "metadata": {},
@@ -623,7 +623,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5d870ec4a6da42cf908efee76a9812d7",
+       "model_id": "01e3f1a9fd4a4906ae372cda59e743b6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -669,7 +669,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b3bfc1995e4445308816edab25ab0c23",
+       "model_id": "86f97aebb6454a2f9a245cc2bc6e11d3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -725,7 +725,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b7399e90df734da9b2426cd630c1ae1f",
+       "model_id": "c8c9be3dcd5b46f9a7c6cbb48e1a6537",
        "version_major": 2,
        "version_minor": 0
       },
@@ -771,7 +771,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "148ab43a59324562b67d1a94529a534b",
+       "model_id": "77a3cf9121f1447494dd154bd4864fd6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -817,7 +817,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1467bb57fcdc4ac6a14e84e8aba8d64e",
+       "model_id": "6d64193f1fb24bcaa3657b726a8f6134",
        "version_major": 2,
        "version_minor": 0
       },
@@ -866,7 +866,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "67741de0da8749ca8e9a25612c8b6bb5",
+       "model_id": "ffd8ae3ac1574dee8cd1258fcb0297a6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -910,7 +910,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7627a7b1f87749298767902d0532923a",
+       "model_id": "d2369e8bfe504406b6ee4bfa3d413efc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -930,7 +930,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "Preview(child=TorusBufferGeometry(), shadowMap=WebGLShadowMap())"
+       "Preview(child=TorusBufferGeometry(radius=100.0), shadowMap=WebGLShadowMap())"
       ]
      },
      "metadata": {},
@@ -949,7 +949,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "681692be2ea042588852a33e311ab88d",
+       "model_id": "8f750e1a73c34b1d90b1397d8bf2cd57",
        "version_major": 2,
        "version_minor": 0
       },
@@ -994,7 +994,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "044e1257325a4500ad934a16059f628d",
+       "model_id": "69ae750a623a4e169fa31a8b73794f2c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1054,7 +1054,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0410a77b6fad43f4a4b5cb2462bbf5fc",
+       "model_id": "1fb23807e5e243468d415bdd46aa452f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1116,255 +1116,87 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.4"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "029efdf8a37f4b0a8e6c0b07863524a6": {
+     "0088744555b04206b34bc8ae2a9562f4": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_6a0b93915ab740b6b6172786af9286c1",
-       "layout": "IPY_MODEL_ac0a5ccca766402085472b88891a596a",
-       "shadowMap": "IPY_MODEL_9d1244f8ee19467992e3871df0e685ea"
-      }
-     },
-     "0410a77b6fad43f4a4b5cb2462bbf5fc": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_56a68de622004b3b95392fbb625415b9",
-       "layout": "IPY_MODEL_2446ab5f52524b5d9b7d953b9a5db0ba",
-       "shadowMap": "IPY_MODEL_a3afc425e0f94b52a0a9395431a2eda6"
-      }
-     },
-     "044e1257325a4500ad934a16059f628d": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_787771dd731b4701b8e085287264597b",
-       "layout": "IPY_MODEL_b73ba5af31a44ff08ab19152c78810e9",
-       "shadowMap": "IPY_MODEL_63a5307632634a3aa112460abdb2b643"
-      }
-     },
-     "0f003cb994a7483bb22bfa0b048c5100": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_56668bfa2e28433d96da4c9558deadf0",
-       "layout": "IPY_MODEL_dde663bffaea45018c92f353d213ffc8",
-       "shadowMap": "IPY_MODEL_af2e877b44a3453686f7744cc593148f"
-      }
-     },
-     "140cc45dbb4a46ac83818ba4348d38d6": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "WebGLShadowMapModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": ""
       }
      },
-     "1467bb57fcdc4ac6a14e84e8aba8d64e": {
+     "01e3f1a9fd4a4906ae372cda59e743b6": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "PreviewModel",
       "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_4c34e40299674323b1c7b0e1da0612d3",
-       "layout": "IPY_MODEL_53387fa340424d10a3d9b9f8ca335b44",
-       "shadowMap": "IPY_MODEL_3446abd03e1842b4a47125e130621b1d"
+       "child": "IPY_MODEL_39101620a7e949c698ff6a95c37d0f91",
+       "layout": "IPY_MODEL_538fe162a5254c7484652d494ac553c2",
+       "shadowMap": "IPY_MODEL_9979d4a702a24d8998bc33efbf34366e"
       }
      },
-     "148ab43a59324562b67d1a94529a534b": {
+     "057c7bf7e1df407ab436badf84bfadac": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "RingBufferGeometryModel",
       "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_5596422670b64c9cb009381a8c6e9cfd",
-       "layout": "IPY_MODEL_46e9a2e500734e1fbf79095e397fad34",
-       "shadowMap": "IPY_MODEL_755ba36d9d3d4014b54e68c7902a31b1"
-      }
-     },
-     "14c63d4f688b4a6f996a51434af32266": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "1a2ceb687915425caeab52f2ab158bf0": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "1badb1fbb4da4126bb76d06b0f4fc1f2": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_bc3693a3878f4bb0bb509e555e82038b",
-       "layout": "IPY_MODEL_3a46ae4ce9414fa5866a4be57d907825",
-       "shadowMap": "IPY_MODEL_c7985279b3174d078ad977140797776b"
-      }
-     },
-     "1bc88cd1d5b749ddb29091705855e935": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "1d7c11b4b499415cab1240f533075123": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "BoxGeometryModel",
-      "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": "",
-       "depth": 15,
-       "depthSegments": 15,
-       "heightSegments": 10,
-       "type": "BoxGeometry",
-       "width": 5,
-       "widthSegments": 5
+       "innerRadius": 10,
+       "outerRadius": 25,
+       "phiSegments": 12,
+       "type": "RingBufferGeometry"
       }
      },
-     "1f4956e752ad4ad89ca37657307f3e5e": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "20c109dd994144dcbdef10b4b8e7fe53": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "23baf9e9e21a417e80b9e72f00e4750c": {
+     "0584e177180e45388124c8a80da1a357": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "CircleBufferGeometryModel",
       "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_2a804713b61e45ad8490a0f091f089e2",
-       "layout": "IPY_MODEL_1a2ceb687915425caeab52f2ab158bf0",
-       "shadowMap": "IPY_MODEL_a88f0753534e41e0bf61fffa413a66f9"
-      }
-     },
-     "23ffc7b063ea4e6bb7d04c665a7e6fa2": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_f857d2a4b31542838f8b440f45158927",
-       "layout": "IPY_MODEL_7569e1447c8d41e59936146593deceba",
-       "shadowMap": "IPY_MODEL_1bc88cd1d5b749ddb29091705855e935"
-      }
-     },
-     "2446ab5f52524b5d9b7d953b9a5db0ba": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "26ce2b754e2b4d6ba16d819e6842390e": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "2781226f7f9c483993a111ccf162dcb8": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "2a804713b61e45ad8490a0f091f089e2": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "BoxBufferGeometryModel",
-      "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": "",
-       "depth": 15,
-       "depthSegments": 15,
-       "heightSegments": 10,
-       "type": "BoxBufferGeometry",
-       "width": 5,
-       "widthSegments": 5
+       "radius": 10,
+       "segments": 10,
+       "thetaLength": 5,
+       "thetaStart": 0.25,
+       "type": "CircleBufferGeometry"
       }
      },
-     "2be12ce20cea4722892066d1af82cc5a": {
+     "05d80f3fa05f43b98cef35841b01f639": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.0.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "2d8b8aa8d2954794be43eeea444cdd1a": {
+     "0ce846c416a244cf9426df5dcc99164a": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "WebGLShadowMapModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": ""
       }
      },
-     "2f6c274921924f71a33f56725857a1c0": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "3446abd03e1842b4a47125e130621b1d": {
+     "0e0abf794f07487ba5a509c6e0cae629": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
       "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
+       "child": "IPY_MODEL_e284be7a9ccc499d960d6de5e3a03d10",
+       "layout": "IPY_MODEL_b0f5f209d5bf4c27b3e6a05894722abf",
+       "shadowMap": "IPY_MODEL_2f9ebd20860d4461b138456419b9a6d7"
       }
      },
-     "382bcb439bbf489fb95579aa74481790": {
+     "15bd6b0921b5447ab98ded3fa45b805c": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "CircleGeometryModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": "",
        "radius": 10,
@@ -1374,89 +1206,25 @@
        "type": "CircleGeometry"
       }
      },
-     "3a46ae4ce9414fa5866a4be57d907825": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "3f6f8428ab6645aea44c5ae3904d4526": {
+     "1977fc2fd0894623b15d4e363a896252": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "SphereGeometryModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PlaneGeometryModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": "",
-       "phiLength": 4.71238898038469,
-       "radius": 20,
-       "thetaLength": 2.0943951023931953,
-       "type": "SphereGeometry"
+       "height": 15,
+       "heightSegments": 10,
+       "type": "PlaneGeometry",
+       "width": 10,
+       "widthSegments": 5
       }
      },
-     "42235c97dd694f60b21413d4089d3337": {
+     "1e8a096f7fed401fbc0a666f2c5127e4": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "DodecahedronGeometryModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": "",
-       "radius": 10,
-       "type": "DodecahedronGeometry"
-      }
-     },
-     "45f43b8827444da3ae0f268f5f74788c": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "46e9a2e500734e1fbf79095e397fad34": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "4c34e40299674323b1c7b0e1da0612d3": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "TetrahedronGeometryModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": "",
-       "detail": 1,
-       "radius": 10,
-       "type": "TetrahedronGeometry"
-      }
-     },
-     "4f01bef35223459585b2adfc2c7d1fb9": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "53387fa340424d10a3d9b9f8ca335b44": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "5596422670b64c9cb009381a8c6e9cfd": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "SphereBufferGeometryModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": "",
        "phiLength": 4.71238898038469,
@@ -1465,36 +1233,333 @@
        "type": "SphereBufferGeometry"
       }
      },
-     "56668bfa2e28433d96da4c9558deadf0": {
+     "1fb23807e5e243468d415bdd46aa452f": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "IcosahedronGeometryModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
       "state": {
-       "_model_module_version": "0.4.0",
+       "child": "IPY_MODEL_b17c6c5801174008bfe6cd1f6fc40c2f",
+       "layout": "IPY_MODEL_33b906261c2446bd9e281a88bad241e6",
+       "shadowMap": "IPY_MODEL_27199727d4954df58415a2e1c48b7709"
+      }
+     },
+     "27199727d4954df58415a2e1c48b7709": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "2729e4c6b04b4fa0a061b9dbbb7c2298": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "SphereGeometryModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "phiLength": 4.71238898038469,
+       "radius": 20,
+       "thetaLength": 2.0943951023931953,
+       "type": "SphereGeometry"
+      }
+     },
+     "28d78ceb51004f669a745f933615b55a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2d514ec4a04f4e67bd49e18635cb9312": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BoxGeometryModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "depth": 15,
+       "depthSegments": 15,
+       "height": 10,
+       "heightSegments": 10,
+       "type": "BoxGeometry",
+       "width": 5,
+       "widthSegments": 5
+      }
+     },
+     "2e4152e105dc49ff8bbba698cc9be547": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2f9ebd20860d4461b138456419b9a6d7": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "2fe9219c6d4c418a9ca0b63ab9a26322": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "310c4f99cf5c4176a8c364e6f75d6872": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "TorusGeometryModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "arc": 4.71238898038469,
+       "radialSegments": 20,
+       "radius": 20,
+       "tube": 5,
+       "type": "TorusGeometry"
+      }
+     },
+     "332e833369d74e8d9d62a51dcf08d9fb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "33b906261c2446bd9e281a88bad241e6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "37c530393ec14198bcc09c440d81d0b4": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
+      "state": {
+       "child": "IPY_MODEL_3b04a21a7d5c4310a90265bebc7a5927",
+       "layout": "IPY_MODEL_6225c61533b943f09b8f6e74f15253b1",
+       "shadowMap": "IPY_MODEL_d3b3a38d55e14d4699cecb5b8b7606e2"
+      }
+     },
+     "39101620a7e949c698ff6a95c37d0f91": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "RingGeometryModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "innerRadius": 10,
+       "outerRadius": 25,
+       "phiSegments": 12,
+       "type": "RingGeometry"
+      }
+     },
+     "3b04a21a7d5c4310a90265bebc7a5927": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "DodecahedronGeometryModel",
+      "state": {
        "_view_module": null,
        "_view_module_version": "",
        "radius": 10,
-       "type": "IcosahedronGeometry"
+       "type": "DodecahedronGeometry"
       }
      },
-     "56a68de622004b3b95392fbb625415b9": {
+     "3b50a1910a28409380fb34fc307ed90b": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WireframeGeometryModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
       "state": {
-       "_model_module_version": "0.4.0",
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "41c43622c46a49eea050f339a290e1be": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "4281016615d041fe99286dd3f6df574c": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "TetrahedronGeometryModel",
+      "state": {
        "_view_module": null,
        "_view_module_version": "",
-       "geometry": "IPY_MODEL_5afdaedc359f4b59862037d79f95aa72",
-       "type": "WireframeGeometry"
+       "detail": 1,
+       "radius": 10,
+       "type": "TetrahedronGeometry"
       }
      },
-     "5afdaedc359f4b59862037d79f95aa72": {
+     "42bc7d813576405fbc7e9bc78c64025e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "461fe72660a343808d889796fa1d99c7": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "47618320a819479aa1acfd7104bcbcd0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "519cc00a3aa44386be99c163e229924c": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "538fe162a5254c7484652d494ac553c2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "552b44c41676472f9a3f3b09502bca73": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "565a42ada56a456b80d4a9411a9c7808": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
+      "state": {
+       "child": "IPY_MODEL_1977fc2fd0894623b15d4e363a896252",
+       "layout": "IPY_MODEL_05d80f3fa05f43b98cef35841b01f639",
+       "shadowMap": "IPY_MODEL_6d25553dfc6e42dcb3e302c11bedc272"
+      }
+     },
+     "5acb53162aaa4d4ebd07aa9ce5934e79": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5b3f28cdc1fb4621b70c55b89e6a71f5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5e77925146584791b54d8a375913c6a7": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
+      "state": {
+       "child": "IPY_MODEL_0584e177180e45388124c8a80da1a357",
+       "layout": "IPY_MODEL_b88578e2af764f1da754becea40ebb9d",
+       "shadowMap": "IPY_MODEL_0ce846c416a244cf9426df5dcc99164a"
+      }
+     },
+     "61ff0e0c0e88403d96711ad8c7fc62c7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6225c61533b943f09b8f6e74f15253b1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6287b14bb11f471aa41abd066a03c50f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "669a95703ec740588c925df055a99357": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "TorusBufferGeometryModel",
       "state": {
-       "_model_module_version": "0.4.0",
+       "_view_module": null,
+       "_view_module_version": "",
+       "radius": 100,
+       "type": "TorusBufferGeometry"
+      }
+     },
+     "6820dfcf32b347cbb550e6817108480f": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
+      "state": {
+       "child": "IPY_MODEL_fbe05db9a5f846fa853f20788d6bbfd0",
+       "layout": "IPY_MODEL_28d78ceb51004f669a745f933615b55a",
+       "shadowMap": "IPY_MODEL_ee5cfeea35b34c41a1d0edf42988d413"
+      }
+     },
+     "69ae750a623a4e169fa31a8b73794f2c": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
+      "state": {
+       "child": "IPY_MODEL_bb5b68fdf640446f8a875094e9f8f3a7",
+       "layout": "IPY_MODEL_61ff0e0c0e88403d96711ad8c7fc62c7",
+       "shadowMap": "IPY_MODEL_c4310bd64f32492c952f56169d78f473"
+      }
+     },
+     "69b887e0a5b7449e91e947f4cc6da3d1": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "6d25553dfc6e42dcb3e302c11bedc272": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "6d64193f1fb24bcaa3657b726a8f6134": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
+      "state": {
+       "child": "IPY_MODEL_4281016615d041fe99286dd3f6df574c",
+       "layout": "IPY_MODEL_dbf6928aad264808bbdfd66d410e3205",
+       "shadowMap": "IPY_MODEL_a0af3a95c05f46e0a8c5f5dde8942956"
+      }
+     },
+     "77363b70920b4e0a82380a4b22794549": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "TorusBufferGeometryModel",
+      "state": {
        "_view_module": null,
        "_view_module_version": "",
        "radialSegments": 6,
@@ -1504,126 +1569,182 @@
        "type": "TorusBufferGeometry"
       }
      },
-     "5d870ec4a6da42cf908efee76a9812d7": {
+     "77a3cf9121f1447494dd154bd4864fd6": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "PreviewModel",
       "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_cda14b8b05714e9ca9eb8397ab4e8232",
-       "layout": "IPY_MODEL_1f4956e752ad4ad89ca37657307f3e5e",
-       "shadowMap": "IPY_MODEL_4f01bef35223459585b2adfc2c7d1fb9"
+       "child": "IPY_MODEL_1e8a096f7fed401fbc0a666f2c5127e4",
+       "layout": "IPY_MODEL_fc43c8bc5ede4ab0934a7d73b5e7500f",
+       "shadowMap": "IPY_MODEL_7901dbeec6d4478cb98a1e7e7e7c56d8"
       }
      },
-     "63a5307632634a3aa112460abdb2b643": {
+     "7901dbeec6d4478cb98a1e7e7e7c56d8": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "WebGLShadowMapModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": ""
       }
      },
-     "63ec9cc26864460691454488cd3dc851": {
+     "7e75685b60a24f0688812ba6c0830aee": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
+      "state": {
+       "child": "IPY_MODEL_f64e5bea635d4025aeb47fc8f7c46f74",
+       "layout": "IPY_MODEL_6287b14bb11f471aa41abd066a03c50f",
+       "shadowMap": "IPY_MODEL_877525f0fa73414b9348ff0bb04873d1"
+      }
+     },
+     "7f0a7670619d430f950ad0ba387bbfa6": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "WebGLShadowMapModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": ""
       }
      },
-     "67741de0da8749ca8e9a25612c8b6bb5": {
+     "86f97aebb6454a2f9a245cc2bc6e11d3": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "PreviewModel",
       "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_a3808705eb4a454b8d6a9fadd18646ef",
-       "layout": "IPY_MODEL_780f986e558e4d9988e0c1a29568fcc4",
-       "shadowMap": "IPY_MODEL_af9aa7fea8a24310a92fb95e19387dd5"
+       "child": "IPY_MODEL_057c7bf7e1df407ab436badf84bfadac",
+       "layout": "IPY_MODEL_47618320a819479aa1acfd7104bcbcd0",
+       "shadowMap": "IPY_MODEL_519cc00a3aa44386be99c163e229924c"
       }
      },
-     "681692be2ea042588852a33e311ab88d": {
+     "877525f0fa73414b9348ff0bb04873d1": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "8d8761e816894c9881a2e62a5c1ff653": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8f5863d0c66f4c39b210582f04a81a49": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8f750e1a73c34b1d90b1397d8bf2cd57": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "PreviewModel",
       "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_e97f2658aaff494ca5290db9a6d3e3bf",
-       "layout": "IPY_MODEL_c6fe2122c3384a3b8f014c657144d1eb",
-       "shadowMap": "IPY_MODEL_45f43b8827444da3ae0f268f5f74788c"
+       "child": "IPY_MODEL_d10e9840411d408386485de7d3b66762",
+       "layout": "IPY_MODEL_c9dc3f4fab9f4fb8aed2acdfa6089131",
+       "shadowMap": "IPY_MODEL_0088744555b04206b34bc8ae2a9562f4"
       }
      },
-     "6a0b93915ab740b6b6172786af9286c1": {
+     "9225e0494cff4fd3916810f0f5732c6c": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PlaneGeometryModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "CylinderBufferGeometryModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": "",
        "height": 15,
        "heightSegments": 10,
-       "type": "PlaneGeometry",
+       "radiusBottom": 10,
+       "radiusTop": 5,
+       "type": "CylinderBufferGeometry"
+      }
+     },
+     "95b6d16a81dc48e5bc6667150de2f64e": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "BoxBufferGeometryModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "depth": 15,
+       "depthSegments": 15,
+       "height": 10,
+       "heightSegments": 10,
+       "type": "BoxBufferGeometry",
+       "width": 5,
        "widthSegments": 5
       }
      },
-     "71da377de8d9458eaf9352ef077fb31e": {
+     "9979d4a702a24d8998bc33efbf34366e": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "WebGLShadowMapModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": ""
       }
      },
-     "755ba36d9d3d4014b54e68c7902a31b1": {
+     "9a18418481bf4a39a3d086912e5cda09": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "OctahedronGeometryModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "radius": 10,
+       "type": "OctahedronGeometry"
+      }
+     },
+     "a0af3a95c05f46e0a8c5f5dde8942956": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "WebGLShadowMapModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": ""
       }
      },
-     "7569e1447c8d41e59936146593deceba": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "7627a7b1f87749298767902d0532923a": {
+     "aabb3f3575dd43b4877c02b6e5707a3d": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "PreviewModel",
       "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_b5ce510ff5ec40328da5c72e0f3388c6",
-       "layout": "IPY_MODEL_e98b999bf8ee465098273c16b7a70020",
-       "shadowMap": "IPY_MODEL_d369f004217b45b1b6f54fa7453d4e89"
+       "child": "IPY_MODEL_15bd6b0921b5447ab98ded3fa45b805c",
+       "layout": "IPY_MODEL_8d8761e816894c9881a2e62a5c1ff653",
+       "shadowMap": "IPY_MODEL_da52f9134acc4b2b9ba22f3d95f3ce6d"
       }
      },
-     "780f986e558e4d9988e0c1a29568fcc4": {
+     "b0f5f209d5bf4c27b3e6a05894722abf": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.0.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "787771dd731b4701b8e085287264597b": {
+     "b17c6c5801174008bfe6cd1f6fc40c2f": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WireframeGeometryModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "geometry": "IPY_MODEL_77363b70920b4e0a82380a4b22794549",
+       "type": "WireframeGeometry"
+      }
+     },
+     "b88578e2af764f1da754becea40ebb9d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bb5b68fdf640446f8a875094e9f8f3a7": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "TorusKnotBufferGeometryModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": "",
        "radius": 20,
@@ -1631,22 +1752,156 @@
        "type": "TorusKnotBufferGeometry"
       }
      },
-     "7e94f2ae10284306964789f04748c2f6": {
+     "be34347f79d541f5aecc724c1709dbe1": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
+      "state": {
+       "child": "IPY_MODEL_9a18418481bf4a39a3d086912e5cda09",
+       "layout": "IPY_MODEL_42bc7d813576405fbc7e9bc78c64025e",
+       "shadowMap": "IPY_MODEL_2fe9219c6d4c418a9ca0b63ab9a26322"
+      }
+     },
+     "c0a6d80e32e04b8e9ecb513a97c29c44": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
+      "state": {
+       "child": "IPY_MODEL_2d514ec4a04f4e67bd49e18635cb9312",
+       "layout": "IPY_MODEL_c1eed44320fc40adb010724da8320a84",
+       "shadowMap": "IPY_MODEL_ebc4356a4057464394b8adebedf909e1"
+      }
+     },
+     "c1eed44320fc40adb010724da8320a84": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c4310bd64f32492c952f56169d78f473": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "WebGLShadowMapModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": ""
       }
      },
-     "8b3ca199e88542cb8147e404017126a4": {
+     "c48f7db415cf4160a6e54544e4a0ff81": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c8c9be3dcd5b46f9a7c6cbb48e1a6537": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
+      "state": {
+       "child": "IPY_MODEL_2729e4c6b04b4fa0a061b9dbbb7c2298",
+       "layout": "IPY_MODEL_2e4152e105dc49ff8bbba698cc9be547",
+       "shadowMap": "IPY_MODEL_7f0a7670619d430f950ad0ba387bbfa6"
+      }
+     },
+     "c9dc3f4fab9f4fb8aed2acdfa6089131": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d10e9840411d408386485de7d3b66762": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "TorusKnotGeometryModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "radius": 20,
+       "tube": 5,
+       "type": "TorusKnotGeometry"
+      }
+     },
+     "d2369e8bfe504406b6ee4bfa3d413efc": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
+      "state": {
+       "child": "IPY_MODEL_669a95703ec740588c925df055a99357",
+       "layout": "IPY_MODEL_5b3f28cdc1fb4621b70c55b89e6a71f5",
+       "shadowMap": "IPY_MODEL_db2137ab75fc49c4aac157a667dc1c99"
+      }
+     },
+     "d28fa3cf072f4ccd8b8c8bd2646dabb8": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
+      "state": {
+       "child": "IPY_MODEL_9225e0494cff4fd3916810f0f5732c6c",
+       "layout": "IPY_MODEL_332e833369d74e8d9d62a51dcf08d9fb",
+       "shadowMap": "IPY_MODEL_461fe72660a343808d889796fa1d99c7"
+      }
+     },
+     "d3b3a38d55e14d4699cecb5b8b7606e2": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "d7e2ec33ecd04951bdeba960d22d6f12": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "ParametricGeometryModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": "",
+       "func": "function(u,v) { \n        var x = 5 * (0.5 - u);\n        var y = 5 * (0.5 - v);\n        return new THREE.Vector3(10 * x, 10 * y, x*x - y*y); \n    }",
+       "slices": 5,
+       "stacks": 10,
+       "type": "ParametricGeometry"
+      }
+     },
+     "da52f9134acc4b2b9ba22f3d95f3ce6d": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "db2137ab75fc49c4aac157a667dc1c99": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "WebGLShadowMapModel",
+      "state": {
+       "_view_module": null,
+       "_view_module_version": ""
+      }
+     },
+     "dbf6928aad264808bbdfd66d410e3205": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dd84ce98756e4f30988caebe9c36c439": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
+      "state": {
+       "child": "IPY_MODEL_95b6d16a81dc48e5bc6667150de2f64e",
+       "layout": "IPY_MODEL_c48f7db415cf4160a6e54544e4a0ff81",
+       "shadowMap": "IPY_MODEL_69b887e0a5b7449e91e947f4cc6da3d1"
+      }
+     },
+     "e284be7a9ccc499d960d6de5e3a03d10": {
+      "model_module": "jupyter-threejs",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "LatheBufferGeometryModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": "",
        "points": [
@@ -1675,379 +1930,70 @@
        "type": "LatheBufferGeometry"
       }
      },
-     "8e6ce3d8be2b4d51839370dc75a76d92": {
+     "e6b4f575041e427cb0206d0d5da15cf3": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "PreviewModel",
       "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_d5a864b3ddfa43d5b64e4d035cdb5ecb",
-       "layout": "IPY_MODEL_e4ad8ccaa4fd4f7389fd2050a4fa5257",
-       "shadowMap": "IPY_MODEL_7e94f2ae10284306964789f04748c2f6"
+       "child": "IPY_MODEL_eefbc26716e64559908537886dd082ce",
+       "layout": "IPY_MODEL_5acb53162aaa4d4ebd07aa9ce5934e79",
+       "shadowMap": "IPY_MODEL_3b50a1910a28409380fb34fc307ed90b"
       }
      },
-     "91c565117edc44e48cbc48bf37637cc8": {
+     "ebc4356a4057464394b8adebedf909e1": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_af2c8db535cd4575aba7af9a1563d236",
-       "layout": "IPY_MODEL_feb1a38239094151b5ed70bb34fe6cb4",
-       "shadowMap": "IPY_MODEL_b4e9392126e44f568d9f45d7f1cc71de"
-      }
-     },
-     "99d32d6e450c469ab744501c8842205f": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_42235c97dd694f60b21413d4089d3337",
-       "layout": "IPY_MODEL_de3f010590f14501bbece8fc28545ec7",
-       "shadowMap": "IPY_MODEL_140cc45dbb4a46ac83818ba4348d38d6"
-      }
-     },
-     "9d1244f8ee19467992e3871df0e685ea": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "WebGLShadowMapModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": ""
       }
      },
-     "a2b539854afe4dbb873326de9a5cfb81": {
+     "ee5cfeea35b34c41a1d0edf42988d413": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_a4e75c37f5c04d39a13b27f541e81095",
-       "layout": "IPY_MODEL_ddc626bdfaaf4b7c84bb5078ada67d1f",
-       "shadowMap": "IPY_MODEL_2d8b8aa8d2954794be43eeea444cdd1a"
-      }
-     },
-     "a3808705eb4a454b8d6a9fadd18646ef": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "TorusGeometryModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": "",
-       "arc": 4.71238898038469,
-       "radialSegments": 20,
-       "radius": 20,
-       "tube": 5,
-       "type": "TorusGeometry"
-      }
-     },
-     "a3afc425e0f94b52a0a9395431a2eda6": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "WebGLShadowMapModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": ""
       }
      },
-     "a4e75c37f5c04d39a13b27f541e81095": {
+     "eefbc26716e64559908537886dd082ce": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "CircleBufferGeometryModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": "",
-       "radius": 10,
-       "segments": 10,
-       "thetaLength": 5,
-       "thetaStart": 0.25,
-       "type": "CircleBufferGeometry"
-      }
-     },
-     "a88f0753534e41e0bf61fffa413a66f9": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "ac0a5ccca766402085472b88891a596a": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "af2c8db535cd4575aba7af9a1563d236": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "PlaneBufferGeometryModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": "",
        "height": 15,
        "heightSegments": 10,
        "type": "PlaneBufferGeometry",
+       "width": 10,
        "widthSegments": 5
       }
      },
-     "af2e877b44a3453686f7744cc593148f": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
+     "f2f141c504f1469bb5b2c64ed9c65c36": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
      },
-     "af9aa7fea8a24310a92fb95e19387dd5": {
+     "f64e5bea635d4025aeb47fc8f7c46f74": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "IcosahedronGeometryModel",
       "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "b3bfc1995e4445308816edab25ab0c23": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_f2d21fdd86df41feb62291bd8f505e65",
-       "layout": "IPY_MODEL_2781226f7f9c483993a111ccf162dcb8",
-       "shadowMap": "IPY_MODEL_eaa015a7100545bebd19a913e276a619"
-      }
-     },
-     "b4e9392126e44f568d9f45d7f1cc71de": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "b5ce510ff5ec40328da5c72e0f3388c6": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "TorusBufferGeometryModel",
-      "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": "",
-       "type": "TorusBufferGeometry"
+       "radius": 10,
+       "type": "IcosahedronGeometry"
       }
      },
-     "b70a7dbc0d644cbeb8aed0c9718d1dd4": {
+     "fbe05db9a5f846fa853f20788d6bbfd0": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_1d7c11b4b499415cab1240f533075123",
-       "layout": "IPY_MODEL_fe77f77ed6424f0ba56b8a9b0289fe73",
-       "shadowMap": "IPY_MODEL_fd7415cb91ec4bfb8e12d2fe1f5969f3"
-      }
-     },
-     "b7399e90df734da9b2426cd630c1ae1f": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_3f6f8428ab6645aea44c5ae3904d4526",
-       "layout": "IPY_MODEL_2be12ce20cea4722892066d1af82cc5a",
-       "shadowMap": "IPY_MODEL_63ec9cc26864460691454488cd3dc851"
-      }
-     },
-     "b73ba5af31a44ff08ab19152c78810e9": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "bc3693a3878f4bb0bb509e555e82038b": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "CylinderBufferGeometryModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": "",
-       "height": 15,
-       "heightSegments": 10,
-       "radiusBottom": 10,
-       "radiusTop": 5,
-       "type": "CylinderBufferGeometry"
-      }
-     },
-     "c0ece6675b83434490a98f43d2bb7c77": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "c2238c75c93e49e4a5fd1b3d4f2c677b": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_382bcb439bbf489fb95579aa74481790",
-       "layout": "IPY_MODEL_26ce2b754e2b4d6ba16d819e6842390e",
-       "shadowMap": "IPY_MODEL_14c63d4f688b4a6f996a51434af32266"
-      }
-     },
-     "c6fe2122c3384a3b8f014c657144d1eb": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "c7985279b3174d078ad977140797776b": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "cc899f646acf4669a29a82fb71886cda": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "PreviewModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_ebc02c2f2f0742edaca8fce8cc59c28f",
-       "layout": "IPY_MODEL_20c109dd994144dcbdef10b4b8e7fe53",
-       "shadowMap": "IPY_MODEL_71da377de8d9458eaf9352ef077fb31e"
-      }
-     },
-     "cda14b8b05714e9ca9eb8397ab4e8232": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "RingGeometryModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": "",
-       "innerRadius": 10,
-       "outerRadius": 25,
-       "phiSegments": 12,
-       "type": "RingGeometry"
-      }
-     },
-     "d369f004217b45b1b6f54fa7453d4e89": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "d5a864b3ddfa43d5b64e4d035cdb5ecb": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "ParametricGeometryModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": "",
-       "func": "function(u,v) { \n        var x = 5 * (0.5 - u);\n        var y = 5 * (0.5 - v);\n        return new THREE.Vector3(10 * x, 10 * y, x*x - y*y); \n    }",
-       "slices": 5,
-       "stacks": 10,
-       "type": "ParametricGeometry"
-      }
-     },
-     "ddc626bdfaaf4b7c84bb5078ada67d1f": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "dde663bffaea45018c92f353d213ffc8": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "de3f010590f14501bbece8fc28545ec7": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "e4ad8ccaa4fd4f7389fd2050a4fa5257": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "e97f2658aaff494ca5290db9a6d3e3bf": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "TorusKnotGeometryModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": "",
-       "radius": 20,
-       "tube": 5,
-       "type": "TorusKnotGeometry"
-      }
-     },
-     "e98b999bf8ee465098273c16b7a70020": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "eaa015a7100545bebd19a913e276a619": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "ebc02c2f2f0742edaca8fce8cc59c28f": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "CylinderGeometryModel",
       "state": {
-       "_model_module_version": "0.4.0",
        "_view_module": null,
        "_view_module_version": "",
        "height": 15,
@@ -2057,65 +2003,31 @@
        "type": "CylinderGeometry"
       }
      },
-     "ed4a030057d4483d8200c45ecf58c840": {
+     "fc43c8bc5ede4ab0934a7d73b5e7500f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ffd8ae3ac1574dee8cd1258fcb0297a6": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
+      "model_module_version": "1.0.0-beta.4",
       "model_name": "PreviewModel",
       "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module_version": "0.4.0",
-       "child": "IPY_MODEL_8b3ca199e88542cb8147e404017126a4",
-       "layout": "IPY_MODEL_2f6c274921924f71a33f56725857a1c0",
-       "shadowMap": "IPY_MODEL_c0ece6675b83434490a98f43d2bb7c77"
+       "child": "IPY_MODEL_310c4f99cf5c4176a8c364e6f75d6872",
+       "layout": "IPY_MODEL_8f5863d0c66f4c39b210582f04a81a49",
+       "shadowMap": "IPY_MODEL_552b44c41676472f9a3f3b09502bca73"
       }
      },
-     "f2d21fdd86df41feb62291bd8f505e65": {
+     "fff3cac17f074f139ffa650ea971089c": {
       "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "RingBufferGeometryModel",
+      "model_module_version": "1.0.0-beta.4",
+      "model_name": "PreviewModel",
       "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": "",
-       "innerRadius": 10,
-       "outerRadius": 25,
-       "phiSegments": 12,
-       "type": "RingBufferGeometry"
+       "child": "IPY_MODEL_d7e2ec33ecd04951bdeba960d22d6f12",
+       "layout": "IPY_MODEL_f2f141c504f1469bb5b2c64ed9c65c36",
+       "shadowMap": "IPY_MODEL_41c43622c46a49eea050f339a290e1be"
       }
-     },
-     "f857d2a4b31542838f8b440f45158927": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "OctahedronGeometryModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": "",
-       "radius": 10,
-       "type": "OctahedronGeometry"
-      }
-     },
-     "fd7415cb91ec4bfb8e12d2fe1f5969f3": {
-      "model_module": "jupyter-threejs",
-      "model_module_version": "0.4.0",
-      "model_name": "WebGLShadowMapModel",
-      "state": {
-       "_model_module_version": "0.4.0",
-       "_view_module": null,
-       "_view_module_version": ""
-      }
-     },
-     "fe77f77ed6424f0ba56b8a9b0289fe73": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "feb1a38239094151b5ed70bb34fe6cb4": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
      }
     },
     "version_major": 2,

--- a/examples/Textures.ipynb
+++ b/examples/Textures.ipynb
@@ -31,7 +31,11 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -70,7 +74,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -150,7 +158,11 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,0 +1,4 @@
+
+def pytest_collectstart(collector):
+    if collector.fspath and collector.fspath.ext == '.ipynb':
+        collector.skip_compare += ('application/vnd.jupyter.widget-view+json', 'text/html')

--- a/js/scripts/generate-wrappers.js
+++ b/js/scripts/generate-wrappers.js
@@ -157,6 +157,15 @@ function getClassConfig(className) {
         classConfigs._defaults
     );
 
+    if ('type' in result.allProperties && result.allProperties.type instanceof Types.String) {
+        if ('type' in result.properties) {
+            result.properties.type.defaultValue = className;
+        } else {
+            result.properties.type = new Types.String(className);
+            result.allProperties.type = result.properties.type;
+        }
+    }
+
     return result;
 }
 

--- a/js/scripts/three-class-config.js
+++ b/js/scripts/three-class-config.js
@@ -102,7 +102,6 @@ module.exports = {
         relativePath: './cameras/CubeCamera',
         superClass: 'Object3D',
         properties: {
-            type: new Types.String('CubeCamera'),
         }
     },
     OrthographicCamera: {
@@ -116,7 +115,6 @@ module.exports = {
             bottom: new Types.Float(),
             near:   new Types.Float(0.1),
             far:    new Types.Float(2000),
-            type:   new Types.String('OrthographicCamera'),
         },
         constructorArgs: [ 'left', 'right', 'top', 'bottom', 'near', 'far' ],
     },
@@ -133,7 +131,6 @@ module.exports = {
             // view:       new Types.Dict(),
             // filmGauge:  new Types.Float(35.0),
             // filmOffset: new Types.Float(0.0),
-            type:   new Types.String('PerspectiveCamera'),
         },
         constructorArgs: [ 'fov', 'aspect', 'near', 'far' ],
     },
@@ -141,7 +138,6 @@ module.exports = {
         relativePath: './cameras/ArrayCamera',
         superClass: 'PerspectiveCamera',
         properties: {
-            type:   new Types.String('ArrayCamera'),
         },
         constructorArgs: [ 'fov', 'aspect', 'near', 'far' ],
     },
@@ -347,7 +343,6 @@ module.exports = {
             attributes:         new Types.ThreeTypeDict(['BufferAttribute', 'InterleavedBufferAttribute']),
             morphAttributes:    new Types.BufferMorphAttributes(),
             MaxIndex:           new Types.Int(65535),
-            type:               new Types.String('BufferGeometry'),
             // TODO: These likely require special types:
             //groups:             new Types.GeometryGroup(),
             //drawRange:          new Types.DrawRange(),
@@ -675,7 +670,6 @@ module.exports = {
             refractionRatio:    new Types.Float(0.98),
             skinning:           new Types.Bool(false),
             specularMap:        new Types.ThreeType('Texture'),
-            type:               new Types.String('MeshBasicMaterial'),
             wireframe:          new Types.Bool(false),
             wireframeLinewidth: new Types.Float(1),
             wireframeLinecap:   new Types.String('round'), // TODO: enum?
@@ -1044,7 +1038,6 @@ module.exports = {
             geometry: new Types.ThreeType(['BaseGeometry', 'BaseBufferGeometry'], {nullable: false}),
             drawMode: new Types.Enum('DrawModes', 'TrianglesDrawMode'),
             morphTargetInfluences: new Types.Array(),
-            type: new Types.String('Mesh'),
         },
         propsDefinedByThree: ['morphTargetInfluences'],
     },
@@ -1682,7 +1675,6 @@ module.exports = {
             hex: new Types.Int(0),
             headLength: new Types.Float(null, {nullable: true}),
             headWidth: new Types.Float(null, {nullable: true}),
-            type: new Types.String('ArrowHelper'),
         },
     },
     AxesHelper: {

--- a/pythreejs/core/BufferGeometry.py
+++ b/pythreejs/core/BufferGeometry.py
@@ -1,7 +1,7 @@
 
 from ipywidgets import register, widget_serialization
-from traitlets import validate, TraitError
-from ipydatawidgets import NDArrayWidget
+from traitlets import validate, TraitError, Undefined
+from ipydatawidgets import NDArrayWidget, get_union_array
 
 from .BufferGeometry_autogen import BufferGeometry as BufferGeometryBase
 
@@ -30,3 +30,43 @@ class BufferGeometry(BufferGeometryBase):
                 raise TraitError('Index attribute must be a flat array. Consider using array.ravel().')
 
         return value
+
+
+    def _gen_repr_from_keys(self, keys):
+        # Hide data in repr to avoid overly large datasets
+        # Replace with uuids of buffer attributes
+        class_name = self.__class__.__name__
+        signature_parts = [
+            '%s=%r' % (key, getattr(self, key))
+            for key in keys if key not in ('attributes', 'morphAttributes')
+        ]
+        for name in ('attributes', 'morphAttributes'):
+            if not _dict_is_default(self, name):
+                signature_parts.append('%s=%s' % (name, _attr_dict_repr(getattr(self, name))))
+        return '%s(%s)' % (class_name, ', '.join(signature_parts))
+
+
+def _dict_is_default(ht, name):
+    value = getattr(ht, name)
+    return (
+        getattr(ht.__class__, name).default_value == Undefined and
+        (value is None or len(value) == 0)
+    )
+
+def _attr_value_repr(v):
+    array = get_union_array(v.array)
+    # Return full repr if array size is small:
+    if array.size < 50:
+        return repr(v)
+    # Otherwise, return a summary:
+    return '<%s shape=%r, dtype=%s>' % (v.__class__.__name__, array.shape, array.dtype)
+
+def _attr_dict_repr(d):
+    parts = []
+    for key, value in d.items():
+        if isinstance(value, tuple):
+            value_parts = [_attr_value_repr(v) for v in value]
+        else:
+            value_parts = [_attr_value_repr(value)]
+        parts.append('%r: %s' % (key, ', '.join(value_parts)))
+    return '{%s}' % (', '.join(parts),)

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup_args = {
         'test': [
             'nbval',
             'pytest-check-links',
+            'numpy>=1.14',
         ],
         'examples': [
             'scipy',


### PR DESCRIPTION
- Fixes default value for `types` attribute of many widgets with some special logic in autogen code.
- Make BufferGeometry repr shorter. For big arrays you cannot see the entire array anyway.
- Regenerate examples with embedded state.
