### PR TITLE
fix widgets disappearing after several displays of a renderer

### DIFF
--- a/js/src/_base/RendererPool.js
+++ b/js/src/_base/RendererPool.js
@@ -26,7 +26,7 @@ _.extend(KeyedCollection.prototype, {
     pop: function(key) {
         for (var i=0, l=this._collection.length; i < l; ++i) {
             var el = this._collection[i];
-            if (el.key == key) {
+            if (_.isEqual(el.key, key)) {
                 this._collection.splice(i, 1);
                 return el.value;
             }

--- a/js/src/_base/RendererPool.js
+++ b/js/src/_base/RendererPool.js
@@ -101,6 +101,9 @@ _.extend(RendererPool.prototype, {
         if (this.freePool.length() > 0) {
 
             renderer = this.freePool.pop(config);
+            if (renderer) {
+                renderer = renderer.renderer;
+            }
             if (!renderer) {
                 var oldRenderer = this.freePool.shift();
                 renderer = this._replaceRenderer(oldRenderer, config);

--- a/js/src/_base/RendererPool.js
+++ b/js/src/_base/RendererPool.js
@@ -55,6 +55,10 @@ _.extend(KeyedCollection.prototype, {
         }
         return null;
     },
+
+    length: function() {
+        return this._collection.length;
+    },
 });
 
 function RendererPool() {
@@ -94,7 +98,7 @@ _.extend(RendererPool.prototype, {
         var renderer;
         console.debug('RendererPool.acquiring...');
 
-        if (this.freePool.length > 0) {
+        if (this.freePool.length() > 0) {
 
             renderer = this.freePool.pop(config);
             if (!renderer) {


### PR DESCRIPTION
There were a few minor bugs in the `KeyedCollection` and the `acquire` function causing `freePool` not to be used and `this.numCreated` exceeding `MAX_RENDERERS` after a few displays.