### PR TITLE
Coerce 64-bit ints as well as floats

### DIFF
--- a/pythreejs/traits.py
+++ b/pythreejs/traits.py
@@ -158,7 +158,6 @@ class WebGLDataUnion(DataUnion):
     """
     def validate(self, obj, value):
         was_original_array = isinstance(value, np.ndarray)
-        print(value, was_original_array)
         value = super(WebGLDataUnion, self).validate(obj, value)
         array = value.array if isinstance(value, NDArrayWidget) else value
 


### PR DESCRIPTION
The base class warns about 64-bit ints in the serializer, which is mostly a source of noice. Here, we try to be smarter about it by casting on validation, and only giving a warning if the original source was another ndarray.

Closes #164.