### PR TITLE
Re-enable JS side support for older widgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         include:
           - python: 3.7
             dist: 'pythreejs*.tar.gz'
-            node: 12
+            node: 14
             lab: 1
           - python: 3.8
             dist: 'pythreejs*.whl'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           - python: 3.7
             dist: 'pythreejs*.tar.gz'
             node: 14
-            lab: 1
+            lab: 2
           - python: 3.8
             dist: 'pythreejs*.whl'
             node: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,19 +138,21 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.7, 3.8, 3.9, 3.10]
         include:
-          - python: 3.6
-            dist: 'pythreejs*.tar.gz'
           - python: 3.7
-            dist: 'pythreejs*.whl'
+            dist: 'pythreejs*.tar.gz'
+            node: 12
             lab: 1
-            node: 10
           - python: 3.8
             dist: 'pythreejs*.whl'
-            lab: 2
             node: 14
+            lab: 2
           - python: 3.9
+            node: 16
+            dist: 'pythreejs*.whl'
+            lab: 3
+          - python: 3.10
             dist: 'pythreejs*.whl'
             lab: 3
           - os: windows

--- a/js/package.json
+++ b/js/package.json
@@ -34,7 +34,7 @@
     "watch": "webpack --mode development -w"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^6.0.0-rc.0",
+    "@jupyter-widgets/base": "^1.2.5 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^6.0.0-rc.0",
     "bluebird": "^3.5.5",
     "jupyter-dataserializers": "^3.0.0",
     "three": "^0.97.0",

--- a/js/src/_base/Renderable.js
+++ b/js/src/_base/Renderable.js
@@ -423,7 +423,7 @@ class RenderableView extends widgets.DOMWidgetView {
         this.$renderer = $(this.renderer.domElement);
         this.$el.empty().append(this.$renderer);
 
-        this.$el.css('margin-bottom', '-5px');
+        this.$el.css('display', 'block');
 
         this.updateSize();
 


### PR DESCRIPTION
Was previously disabled to force the install of RC during testing