### PR TITLE
Fix lumino message handling (context menu)

### DIFF
--- a/js/src/_base/Renderable.js
+++ b/js/src/_base/Renderable.js
@@ -197,8 +197,8 @@ class RenderableView extends widgets.DOMWidgetView {
         }
     }
 
-    processPhosphorMessage(msg) {
-        widgets.DOMWidgetView.prototype.processPhosphorMessage.call(this, msg);
+    _processLuminoMessage(msg, _super) {
+        _super.call(this, msg);
         switch (msg.type) {
         case 'after-attach':
             this.el.addEventListener('contextmenu', this, true);
@@ -207,6 +207,14 @@ class RenderableView extends widgets.DOMWidgetView {
             this.el.removeEventListener('contextmenu', this, true);
             break;
         }
+    }
+
+    processPhosphorMessage(msg) {
+        this._processLuminoMessage(msg, widgets.DOMWidgetView.prototype.processPhosphorMessage);
+    }
+
+    processLuminoMessage(msg) {
+        this._processLuminoMessage(msg, widgets.DOMWidgetView.prototype.processLuminoMessage);
     }
 
     handleEvent(event) {

--- a/setupbase.py
+++ b/setupbase.py
@@ -659,7 +659,7 @@ def _translate_glob(pat):
         translated_parts.append(_translate_glob_part(part))
     os_sep_class = '[%s]' % re.escape(SEPARATORS)
     res = _join_translated(translated_parts, os_sep_class)
-    return '{res}\\Z(?ms)'.format(res=res)
+    return '(?ms){res}\\Z'.format(res=res)
 
 
 def _join_translated(translated_parts, os_sep_class):


### PR DESCRIPTION
Without this compatibility shim (https://ipywidgets.readthedocs.io/en/stable/migration_guides.html#phosphor-lumino), we no longer handle `contextmenu` events correctly (with ipywidgets 8).

Fixes #392.