### PR TITLE
Use get_cmap from matplotlib.colormaps

### DIFF
--- a/examples/Examples.ipynb
+++ b/examples/Examples.ipynb
@@ -178,7 +178,7 @@
     "import matplotlib.pyplot as plt\n",
     "from skimage import img_as_ubyte \n",
     "\n",
-    "jet = matplotlib.cm.get_cmap('jet')\n",
+    "jet = matplotlib.colormaps.get_cmap('jet')\n",
     "\n",
     "np.random.seed(int(1)) # start random number generator\n",
     "n = int(5) # starting points\n",

--- a/pythreejs/pythreejs.py
+++ b/pythreejs/pythreejs.py
@@ -231,7 +231,7 @@ def make_text(text, position=(0, 0, 0), height=1):
 
 def height_texture(z, colormap='viridis'):
     """Create a texture corresponding to the heights in z and the given colormap."""
-    from matplotlib import cm
+    from matplotlib import colormaps as cm
     from skimage import img_as_ubyte
 
     colormap = cm.get_cmap(colormap)


### PR DESCRIPTION
matplotlib.cm.get_cmap is deprecated, the documentation recommends to use matplotlib.colormaps.get_cmap instead.

https://matplotlib.org/stable/api/cm_api.html#matplotlib.cm.get_cmap